### PR TITLE
Fix removed evaluator import in entrypoint

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,6 @@ const { evaluate } = require('./evaluator')
 module.exports = {
   scan,
   parse,
-  evaluate,
 
   /**
    * Evaluate a radspec expression with manual bindings.

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const { evaluate } = require('./evaluator')
 module.exports = {
   scan,
   parse,
+  evaluate,
 
   /**
    * Evaluate a radspec expression with manual bindings.

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@
 const ABI = require('web3-eth-abi')
 const { scan } = require('./scanner')
 const { parse } = require('./parser')
+const { evaluate } = require('./evaluator')
 
 module.exports = {
   scan,
@@ -68,12 +69,12 @@ module.exports = {
   evaluate (source, call) {
     // Get method ID
     const methodId = call.transaction.data.substr(0, 10)
-    
+
     // Find method ABI
     const method = call.abi.find((abi) =>
       abi.type === 'function' &&
       methodId === ABI.encodeFunctionSignature(abi))
-    
+
     // Decode parameters
     const parameterValues = ABI.decodeParameters(
       method.inputs,


### PR DESCRIPTION
Got removed as part of this commit: https://github.com/aragon/radspec/commit/f4f578364425474459891724d30050655b016b23