### PR TITLE
Support bytes and address literals

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1685,7 +1685,7 @@
         "bytes": "3.0.0",
         "content-type": "1.0.4",
         "debug": "2.6.9",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
         "on-finished": "2.3.0",
@@ -2783,9 +2783,9 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-      "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
@@ -3597,7 +3597,7 @@
         "keccakjs": "0.2.1",
         "nano-json-stream-parser": "0.1.2",
         "servify": "0.1.12",
-        "ws": "3.3.2",
+        "ws": "3.3.3",
         "xhr-request-promise": "0.1.2"
       }
     },
@@ -3677,7 +3677,7 @@
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
@@ -5458,6 +5458,13 @@
         "inherits": "2.0.3",
         "setprototypeof": "1.0.3",
         "statuses": "1.4.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
+        }
       }
     },
     "http-https": {
@@ -9885,7 +9892,7 @@
       "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
       "requires": {
         "debug": "2.6.9",
-        "depd": "1.1.1",
+        "depd": "1.1.2",
         "destroy": "1.0.4",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
@@ -11457,7 +11464,7 @@
         "web3-core-helpers": "1.0.0-beta.26",
         "web3-core-method": "1.0.0-beta.26",
         "web3-core-requestmanager": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-core-helpers": {
@@ -11467,7 +11474,7 @@
       "requires": {
         "underscore": "1.8.3",
         "web3-eth-iban": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-core-method": {
@@ -11479,7 +11486,7 @@
         "web3-core-helpers": "1.0.0-beta.26",
         "web3-core-promievent": "1.0.0-beta.26",
         "web3-core-subscriptions": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-core-promievent": {
@@ -11536,7 +11543,7 @@
         "web3-eth-iban": "1.0.0-beta.26",
         "web3-eth-personal": "1.0.0-beta.26",
         "web3-net": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-eth-abi": {
@@ -11547,7 +11554,7 @@
         "bn.js": "4.11.6",
         "underscore": "1.8.3",
         "web3-core-helpers": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-eth-accounts": {
@@ -11563,7 +11570,7 @@
         "web3-core": "1.0.0-beta.26",
         "web3-core-helpers": "1.0.0-beta.26",
         "web3-core-method": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       },
       "dependencies": {
         "bluebird": {
@@ -11600,7 +11607,7 @@
         "web3-core-promievent": "1.0.0-beta.26",
         "web3-core-subscriptions": "1.0.0-beta.26",
         "web3-eth-abi": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-eth-iban": {
@@ -11609,7 +11616,7 @@
       "integrity": "sha1-6MI2GOpapmJ73pHHPqi18ZGe43Q=",
       "requires": {
         "bn.js": "4.11.6",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-eth-personal": {
@@ -11621,7 +11628,7 @@
         "web3-core-helpers": "1.0.0-beta.26",
         "web3-core-method": "1.0.0-beta.26",
         "web3-net": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-net": {
@@ -11631,7 +11638,7 @@
       "requires": {
         "web3-core": "1.0.0-beta.26",
         "web3-core-method": "1.0.0-beta.26",
-        "web3-utils": "1.0.0-beta.26"
+        "web3-utils": "1.0.0-beta.27"
       }
     },
     "web3-providers-http": {
@@ -11664,9 +11671,9 @@
       }
     },
     "web3-utils": {
-      "version": "1.0.0-beta.26",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.26.tgz",
-      "integrity": "sha1-8ErYwUSxeBxrIMKBjgUyy55tyhU=",
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.27.tgz",
+      "integrity": "sha1-0JfVwzaha59sqbYK9o3RXAZDIUs=",
       "requires": {
         "bn.js": "4.11.6",
         "eth-lib": "0.1.27",
@@ -11845,9 +11852,9 @@
       }
     },
     "ws": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.2.tgz",
-      "integrity": "sha512-t+WGpsNxhMR4v6EClXS8r8km5ZljKJzyGhJf7goJz9k5Ye3+b5Bvno5rjqPuIBn5mnn5GBb7o8IrIWHxX1qOLQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+      "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
       "requires": {
         "async-limiter": "1.0.0",
         "safe-buffer": "5.1.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "bignumber.js": "^5.0.0",
     "web3-eth": "^1.0.0-beta.26",
-    "web3-eth-abi": "^1.0.0-beta.26"
+    "web3-eth-abi": "^1.0.0-beta.26",
+    "web3-utils": "^1.0.0-beta.27"
   }
 }

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -1,5 +1,6 @@
 const ABI = require('web3-eth-abi')
 const Eth = require('web3-eth')
+const Web3Utils = require('web3-utils')
 const BigNumber = require('bignumber.js')
 const types = require('../types')
 
@@ -10,6 +11,14 @@ class TypedValue {
 
     if (types.isInteger(this.type)) {
       this.value = new BigNumber(this.value)
+    }
+
+    if (this.type === 'address') {
+      const isChecksum = /[a-f]/.test(this.value)
+
+      if (!Web3Utils.checkAddressChecksum(this.value)) {
+        throw new Error(`Checksum failed for address "${this.value}"`)
+      }
     }
   }
 
@@ -99,6 +108,8 @@ class Evaluator {
       if (target.type !== 'bytes20' &&
         target.type !== 'address') {
         this.panic('Target of call expression was not an address')
+      } else if (!Web3Utils.checkAddressChecksum(target.value)) {
+        this.panic(`Checksum failed for address "${target.value}"`)
       }
 
       const call = ABI.encodeFunctionCall({

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -92,10 +92,14 @@ class Evaluator {
 
     if (node.type === 'CallExpression') {
       // TODO Add a check for number of return values (can only be 1 for now)
-      // TODO Check that target is actually an address
       const target = await this.evaluateNode(node.target)
       const inputs = await this.evaluateNodes(node.inputs)
       const outputs = node.outputs
+
+      if (target.type !== 'bytes20' &&
+        target.type !== 'address') {
+        this.panic('Target of call expression was not an address')
+      }
 
       const call = ABI.encodeFunctionCall({
         name: node.callee,

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -48,6 +48,15 @@ class Evaluator {
       return new TypedValue('int256', node.value)
     }
 
+    if (node.type === 'BytesLiteral') {
+      const length = (node.value.length - 2) / 2
+      if (length > 32) {
+        this.panic('Byte literal represents more than 32 bytes')
+      }
+
+      return new TypedValue(`bytes${length}`, node.value)
+    }
+
     if (node.type === 'BinaryExpression') {
       const left = await this.evaluateNode(node.left)
       const right = await this.evaluateNode(node.right)
@@ -83,6 +92,7 @@ class Evaluator {
 
     if (node.type === 'CallExpression') {
       // TODO Add a check for number of return values (can only be 1 for now)
+      // TODO Check that target is actually an address
       const target = await this.evaluateNode(node.target)
       const inputs = await this.evaluateNodes(node.inputs)
       const outputs = node.outputs

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -255,10 +255,12 @@ class Parser {
    * @return {Node}
    */
   primary () {
-    if (this.matches('NUMBER', 'STRING')) {
-      let type = this.previous().type === 'NUMBER'
-        ? 'NumberLiteral'
-        : 'StringLiteral'
+    if (this.matches('NUMBER', 'STRING', 'HEXADECIMAL')) {
+      let type = {
+        NUMBER: 'NumberLiteral',
+        STRING: 'StringLiteral',
+        HEXADECIMAL: 'BytesLiteral'
+      }[this.previous().type]
 
       return {
         type,

--- a/src/scanner/index.js
+++ b/src/scanner/index.js
@@ -114,12 +114,27 @@ class Scanner {
       // Multi-character tokens
       default:
         const NUMBERS = /[0-9]/
+        const HEX = /[0-9a-f]/i
         if (NUMBERS.test(current)) {
           let number = current
-          while (NUMBERS.test(this.peek())) {
+          let type = 'NUMBER'
+
+          // Detect hexadecimals
+          if (current === '0' &&
+            this.peek() === 'x') {
+            type = 'HEXADECIMAL'
             number += this.consume()
+
+            while (HEX.test(this.peek())) {
+              number += this.consume()
+            }
+          } else {
+            while (NUMBERS.test(this.peek())) {
+              number += this.consume()
+            }
           }
-          this.emitToken('NUMBER', number)
+
+          this.emitToken(type, number)
           break
         }
 

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -36,8 +36,8 @@ const cases = [
   }, 'Allocate 100 ANT.'],
   [{
     source: 'Burns the `token.symbol(): string` balance of `person` (balance is `token.balanceOf(person): uint256 / 1000000000000000000`)',
-    bindings: { token: address('0x960b236A07cf122663c4303350609A66A7B288C0'), person: address('0x0') }
-  }, 'Burns the ANT balance of 0x0 (balance is 0)']
+    bindings: { token: address('0x960b236A07cf122663c4303350609A66A7B288C0'), person: address('0x0000000000000000000000000000000000000000') }
+  }, 'Burns the ANT balance of 0x0000000000000000000000000000000000000000 (balance is 0)']
 ]
 
 test('Examples', async (t) => {

--- a/test/scanner/numbers.js
+++ b/test/scanner/numbers.js
@@ -2,13 +2,22 @@ const test = require('ava')
 const { scan } = require('../../src/scanner')
 
 test('Scanner: Numbers', async (t) => {
-  t.plan(1)
+  t.plan(2)
 
   t.deepEqual(
     await scan('`1234567890`'),
     [
       { type: 'TICK' },
       { type: 'NUMBER', value: '1234567890' },
+      { type: 'TICK' }
+    ]
+  )
+
+  t.deepEqual(
+    await scan('`0xdeadbeef`'),
+    [
+      { type: 'TICK' },
+      { type: 'HEXADECIMAL', value: '0xdeadbeef' },
       { type: 'TICK' }
     ]
   )

--- a/test/types/bytes.js
+++ b/test/types/bytes.js
@@ -1,0 +1,8 @@
+const test = require('ava')
+const bytes = require('../../src/types/bytes')
+
+test('Type: bytes', (t) => {
+  t.true(bytes.isType('byte'), 'Byte should be an alias for bytes1')
+  t.true(bytes.isType('bytes32'))
+  t.false(bytes.isType('bytes64'), 'Maximum length of bytes should be 32')
+})


### PR DESCRIPTION
- Adds new token `HEXADECIMAL`
- Add new AST node `BytesLiteral` (transformed from `HEXADECIMAL` tokens)
- Check that targets in call expressions are actually addresses (`address` or `bytes20`)

Closes #9 