### PR TITLE
Use bn.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1590,11 +1590,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "bignumber.js": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
-      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
-    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "websocket": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
   },
   "dependencies": {
-    "bignumber.js": "^5.0.0",
+    "bn.js": "4.11.6",
     "web3-eth": "1.0.0-beta.33",
     "web3-eth-abi": "1.0.0-beta.33",
     "web3-utils": "1.0.0-beta.33"

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -5,7 +5,7 @@
 const ABI = require('web3-eth-abi')
 const Eth = require('web3-eth')
 const Web3Utils = require('web3-utils')
-const BigNumber = require('bignumber.js')
+const BN = require('bn.js')
 const types = require('../types')
 
 /**
@@ -22,8 +22,8 @@ class TypedValue {
     this.type = type
     this.value = value
 
-    if (types.isInteger(this.type) && !this.value._isBigNumber) {
-      this.value = new BigNumber(this.value)
+    if (types.isInteger(this.type) && !BN.isBN(this.value)) {
+      this.value = new BN(this.value)
     }
 
     if (this.type === 'address') {
@@ -139,7 +139,7 @@ class Evaluator {
         case 'SLASH':
           return new TypedValue('int256', left.value.div(right.value))
         case 'MODULO':
-          return new TypedValue('int256', left.value.modulo(right.value))
+          return new TypedValue('int256', left.value.mod(right.value))
         default:
           this.panic(`Undefined binary operator "${node.operator}"`)
       }

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 const { evaluateRaw } = require('../../src')
-const BN = require('BN.js')
+const BN = require('bn.js')
 
 const int = (value) => ({
   type: 'int256',

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -1,6 +1,6 @@
 const test = require('ava')
 const { evaluateRaw } = require('../../src')
-const BigNumber = require('bignumber.js')
+const BN = require('BN.js')
 
 const int = (value) => ({
   type: 'int256',
@@ -44,6 +44,12 @@ const cases = [
     source: 'First case is `(11 - 1) * 2^5`, second case is `3 * 2 ^ (4 - 1) + 1`'
   }, 'First case is 320, second case is 25'],
   [{
+    source: 'First case is `(11 - 1) / 2`, second case is `3 * 2 ^ (4 - 1) / 3`'
+  }, 'First case is 5, second case is 8'],
+  [{
+    source: 'First case is `(11 - 1) % 3`, second case is `3 * 2 % 5`'
+  }, 'First case is 1, second case is 1'],
+  [{
     source: 'Basic arithmetic: `a` + `b` is `a + b`, - `c` that\'s `a + b - c`, quick mafs',
     bindings: { a: int(2), b: int(2), c: int(1) }
   }, 'Basic arithmetic: 2 + 2 is 4, - 1 that\'s 3, quick mafs'],
@@ -67,7 +73,7 @@ const cases = [
   }, 'Vote nay'],
   [{
     source: 'Token `_amount / 10^18`',
-    bindings: { _amount: int(new BigNumber(10).times(Math.pow(10, 18))) }
+    bindings: { _amount: int(new BN(10).mul(new BN(10).pow(new BN(18)))) }
   }, 'Token 10'],
   [{
     source: '`_bool ? \'h\' + _var + \'o\' : \'damn\'`',
@@ -75,13 +81,14 @@ const cases = [
   }, 'hello']
 ]
 
-test('Examples', async (t) => {
-  for (let [input, expected] of cases) {
+for (let [input, expected] of cases) {
+  test(input.source, async (t) => {
+    t.pass()
     const actual = await evaluateRaw(input.source, input.bindings)
     t.is(
       actual,
       expected,
       `Expected "${input.source}" to evaluate to "${expected}", but evaluated to "${actual}"`
     )
-  }
-})
+  })
+}

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -83,7 +83,6 @@ const cases = [
 
 for (let [input, expected] of cases) {
   test(input.source, async (t) => {
-    t.pass()
     const actual = await evaluateRaw(input.source, input.bindings)
     t.is(
       actual,


### PR DESCRIPTION
`bn.js` is both faster and more widely used than `bignumber.js`, to allow us to dedupe a bunch of modules in `aragon/aragon`.