### PR TITLE
Add default operator

### DIFF
--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -174,6 +174,21 @@ class Evaluator {
       return this.evaluateNode(node.right)
     }
 
+    if (node.type === 'DefaultExpression') {
+      const left = await this.evaluateNode(node.left)
+      let leftFalsey
+
+      if (types.isInteger(left.type)) {
+        leftFalsey = left.value.isZero()
+      } else if (left.type === 'address' || left.type.startsWith('bytes')) {
+        leftFalsey = /^0x[0]*$/.test(left.value)
+      } else {
+        leftFalsey = !left.value
+      }
+
+      return leftFalsey ? this.evaluateNode(node.right) : left
+    }
+
     if (node.type === 'Identifier') {
       if (!this.bindings.hasOwnProperty(node.value)) {
         this.panic(`Undefined binding "${node.value}"`)

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -131,6 +131,14 @@ class Parser {
       node.right = this.comparison()
     }
 
+    if (this.matches('DOUBLE_VERTICAL_BAR')) {
+      node = {
+        left: node,
+        right: this.comparison(),
+        type: 'DefaultExpression'
+      }
+    }
+
     return node
   }
 

--- a/src/scanner/index.js
+++ b/src/scanner/index.js
@@ -113,6 +113,15 @@ class Scanner {
         this.emitToken(this.matches('=') ? 'GREATER_EQUAL' : 'GREATER')
         break
 
+      // Two character tokens
+      case '|':
+        if (this.matches('|')) {
+          this.emitToken('DOUBLE_VERTICAL_BAR')
+        } else {
+          this.report(`Unexpected single "|" (expecting two)`)
+        }
+        break
+
       // Whitespace
       case ' ':
       case '\r':

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -22,6 +22,11 @@ const string = (value) => ({
   value
 })
 
+const bytes32 = (value) => ({
+  type: 'bytes32',
+  value
+})
+
 const cases = [
   // Bindings
   [{
@@ -53,6 +58,21 @@ const cases = [
     source: 'Basic arithmetic: `a` + `b` is `a + b`, - `c` that\'s `a + b - c`, quick mafs',
     bindings: { a: int(2), b: int(2), c: int(1) }
   }, 'Basic arithmetic: 2 + 2 is 4, - 1 that\'s 3, quick mafs'],
+  [{
+    source: 'This will default to `b`: `a || b`',
+    bindings: { a: int(0), b: int(1) }
+  }, 'This will default to 1: 1'],
+  [{
+    source: 'This will default to `a`: `a || b`',
+    bindings: { a: int(1), b: int(0) }
+  }, 'This will default to 1: 1'],
+  [{
+    source: 'This will default to `b`: `a || b`',
+    bindings: {
+      a: bytes32('0x0000000000000000000000000000000000000000000000000000000000000000'),
+      b: int(1)
+    }
+  }, 'This will default to 1: 1'],
 
   // External calls
   [{

--- a/test/scanner/doubles.js
+++ b/test/scanner/doubles.js
@@ -10,7 +10,8 @@ test('Scanner: One or two character tokens', async (t) => {
     ['`<`', ['TICK', 'LESS', 'TICK']],
     ['`<=`', ['TICK', 'LESS_EQUAL', 'TICK']],
     ['`>`', ['TICK', 'GREATER', 'TICK']],
-    ['`>=`', ['TICK', 'GREATER_EQUAL', 'TICK']]
+    ['`>=`', ['TICK', 'GREATER_EQUAL', 'TICK']],
+    ['`||`', ['TICK', 'DOUBLE_VERTICAL_BAR', 'TICK']]
   ]
   t.plan(cases.length)
 


### PR DESCRIPTION
Useful for not duplicating a web3 call.

```
Set control from `owned.owner() || 'no one'` to `sender`
```

Attempts to be useful for all types.