### PR TITLE
Implement equality and inequality comparisons for integers, addresses and bytesX

### DIFF
--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -105,7 +105,7 @@ class Evaluator {
     }
 
     if (node.type === 'BytesLiteral') {
-      const length = (node.value.length - 2) / 2
+      const length = Math.ceil((node.value.length - 2) / 2)
       if (length > 32) {
         this.panic('Byte literal represents more than 32 bytes')
       }

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -166,9 +166,9 @@ class Evaluator {
         types.types.bytes.isType(right.type)
       )
 
-      // Conversion to BN for comparaison will happen if:
+      // Conversion to BN for comparison will happen if:
       // - Both types are addresses or bytes of any size (can be different sizes)
-      // - If one of the types if an address and the other bytes with size less than 20
+      // - If one of the types is an address and the other bytes with size less than 20
       if (bothTypesAddress(left, right) || bothTypesBytes(left, right)) {
         leftValue = Web3Utils.toBN(leftValue)
         rightValue = Web3Utils.toBN(rightValue)

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -27,7 +27,7 @@ class TypedValue {
     }
 
     if (this.type === 'address') {
-      const isChecksum = /[a-f]/.test(this.value)
+      const isChecksum = /[A-F]/.test(this.value)
 
       if (isChecksum && !Web3Utils.checkAddressChecksum(this.value)) {
         throw new Error(`Checksum failed for address "${this.value}"`)

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -107,7 +107,7 @@ class Parser {
   comparison (astBody) {
     let node = this.addition(astBody)
 
-    while (this.matches('GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL')) {
+    while (this.matches('GREATER', 'GREATER_EQUAL', 'LESS', 'LESS_EQUAL', 'EQUAL_EQUAL', 'BANG_EQUAL')) {
       let operator = this.previous().type
       let right = this.addition(astBody)
       node = {

--- a/src/types/bytes.js
+++ b/src/types/bytes.js
@@ -13,14 +13,11 @@ module.exports = {
   },
 
   size (identifier) {
-    let n = identifier.substr(5)
-
     // `byte` is bytes1
-    if (!n && identifier === 'byte') {
+    if (identifier === 'byte') {
       identifier = 'bytes1'
-      n = 1
     }
 
-    return n
+    return identifier.substr(5)
   }
 }

--- a/src/types/bytes.js
+++ b/src/types/bytes.js
@@ -10,5 +10,17 @@ module.exports = {
 
     return identifier.startsWith('bytes') &&
       n <= 32
+  },
+
+  size (identifier) {
+    let n = identifier.substr(5)
+
+    // `byte` is bytes1
+    if (!n && identifier === 'byte') {
+      identifier = 'bytes1'
+      n = 1
+    }
+
+    return n
   }
 }

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -34,5 +34,11 @@ module.exports = {
   isInteger (identifier) {
     return this.types.int.isType(identifier) ||
       this.types.uint.isType(identifier)
+  },
+
+  isAddress (identifier) {
+    return this.types.address.isType(identifier) ||
+      this.types.bytes.isType(identifier) &&
+      this.types.bytes.size(identifier) <= 20
   }
 }

--- a/src/types/index.js
+++ b/src/types/index.js
@@ -37,8 +37,9 @@ module.exports = {
   },
 
   isAddress (identifier) {
-    return this.types.address.isType(identifier) ||
+    return this.types.address.isType(identifier) || (
       this.types.bytes.isType(identifier) &&
       this.types.bytes.size(identifier) <= 20
+    )
   }
 }

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -27,7 +27,79 @@ const bytes32 = (value) => ({
   value
 })
 
+const comparaisonCases = [
+  [{
+    source: '`a > 2`',
+    bindings: { a: int(3) }
+  }, 'true'],
+  [{
+    source: '`a > b`',
+    bindings: { a: int(2), b: int(3) }
+  }, 'false'],
+  [{
+    source: '`a >= b`',
+    bindings: { a: int(3), b: int(2) }
+  }, 'true'],
+  [{
+    source: '`a >= b`',
+    bindings: { a: int(1), b: int(2) }
+  }, 'false'],
+  [{
+    source: '`a >= b`',
+    bindings: { a: int(2), b: int(2) }
+  }, 'true'],
+  [{
+    source: '`a < b`',
+    bindings: { a: int(3), b: int(2) }
+  }, 'false'],
+  [{
+    source: '`a < b`',
+    bindings: { a: int(2), b: int(3) }
+  }, 'true'],
+  [{
+    source: '`a <= b`',
+    bindings: { a: int(3), b: int(2) }
+  }, 'false'],
+  [{
+    source: '`a <= b`',
+    bindings: { a: int(1), b: int(2) }
+  }, 'true'],
+  [{
+    source: '`a <= b`',
+    bindings: { a: int(3), b: int(3) }
+  }, 'true'],
+  [{
+    source: '`a == b`',
+    bindings: { a: int(3), b: int(3) }
+  }, 'true'],
+  [{
+    source: '`a != b`',
+    bindings: { a: int(3), b: int(3) }
+  }, 'false'],
+  [{
+    source: '`a > 0x01`',
+    bindings: { a: address('0x0000000000000000000000000000000000000002') }
+  }, 'true'],
+  [{
+    source: '`a == 0x0`',
+    bindings: { a: address('0x0000000000000000000000000000000000000000') }
+  }, 'true'],
+  [{
+    source: '`a != 0x01`',
+    bindings: { a: address('0x0000000000000000000000000000000000000002') }
+  }, 'true'],
+  [{
+    source: '`a != 0x01`',
+    bindings: { a: address('0x0000000000000000000000000000000000000002') }
+  }, 'true'],
+  [{
+    source: '`a > 0x01`',
+    bindings: { a: bytes32('0x0000000000000000000000000000000000000000000000000000000000000002') }
+  }, 'true']
+]
+
 const cases = [
+  ...comparaisonCases,
   // Bindings
   [{
     source: 'a is `a`, b is `b` and "c d" is `c d`',

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -27,7 +27,7 @@ const bytes32 = (value) => ({
   value
 })
 
-const comparaisonCases = [
+const comparisonCases = [
   [{
     source: '`a > 2`',
     bindings: { a: int(3) }
@@ -99,7 +99,7 @@ const comparaisonCases = [
 ]
 
 const cases = [
-  ...comparaisonCases,
+  ...comparisonCases,
   // Bindings
   [{
     source: 'a is `a`, b is `b` and "c d" is `c d`',


### PR DESCRIPTION
Close #39 

For addresses and bytes types always converts to `BN`, comparisons are allowed even if the bytes are not of the same size, the numeric value will be used directly. Addresses can be compared with byte types of sizes less than or equal 20.