### PR TITLE
Fix build due to improper importing of ES modules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11845,6 +11845,14 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
       "dev": true
     },
+    "typedarray-to-buffer": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
+      "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
+      "requires": {
+        "is-typedarray": "^1.0.0"
+      }
+    },
     "uid2": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
@@ -12574,19 +12582,8 @@
       "integrity": "sha1-j93qQuGbvyUh7IeVRkV6Yjqdye8=",
       "requires": {
         "underscore": "1.8.3",
-        "web3-core-helpers": "1.0.0-beta.33"
-      },
-      "dependencies": {
-        "websocket": {
-          "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "from": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
-          "requires": {
-            "debug": "^2.2.0",
-            "nan": "^2.3.3",
-            "typedarray-to-buffer": "^3.1.2",
-            "yaeti": "^0.0.6"
-          }
-        }
+        "web3-core-helpers": "1.0.0-beta.33",
+        "websocket": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2"
       }
     },
     "web3-utils": {
@@ -12601,6 +12598,16 @@
         "randomhex": "0.1.5",
         "underscore": "1.8.3",
         "utf8": "2.1.1"
+      }
+    },
+    "websocket": {
+      "version": "git://github.com/frozeman/WebSocket-Node.git#6c72925e3f8aaaea8dc8450f97627e85263999f2",
+      "from": "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible",
+      "requires": {
+        "debug": "^2.2.0",
+        "nan": "^2.3.3",
+        "typedarray-to-buffer": "^3.1.2",
+        "yaeti": "^0.0.6"
       }
     },
     "websocket-driver": {
@@ -12797,6 +12804,11 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
       "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
       "dev": true
+    },
+    "yaeti": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/yaeti/-/yaeti-0.0.6.tgz",
+      "integrity": "sha1-8m9ITXJoTPQr7ft2lwqhYI+/lXc="
     },
     "yallist": {
       "version": "2.1.2",

--- a/src/helpers/formatDate.js
+++ b/src/helpers/formatDate.js
@@ -1,4 +1,4 @@
-const formatDate = require('date-fns/format')
+import formatDate from 'date-fns/format'
 
 module.exports = () =>
   /**

--- a/src/helpers/transformTime.js
+++ b/src/helpers/transformTime.js
@@ -1,12 +1,12 @@
-const addMilliseconds = require('date-fns/addMilliseconds')
-const addSeconds = require('date-fns/addSeconds')
-const addMinutes = require('date-fns/addMinutes')
-const addHours = require('date-fns/addHours')
-const addDays = require('date-fns/addDays')
-const addWeeks = require('date-fns/addWeeks')
-const addMonths = require('date-fns/addMonths')
-const addYears = require('date-fns/addYears')
-const formatDistanceStrict = require('date-fns/formatDistanceStrict')
+import addMilliseconds from 'date-fns/addMilliseconds'
+import addSeconds from 'date-fns/addSeconds'
+import addMinutes from 'date-fns/addMinutes'
+import addHours from 'date-fns/addHours'
+import addDays from 'date-fns/addDays'
+import addWeeks from 'date-fns/addWeeks'
+import addMonths from 'date-fns/addMonths'
+import addYears from 'date-fns/addYears'
+import formatDistanceStrict from 'date-fns/formatDistanceStrict'
 
 const BEST_UNIT = 'best'
 


### PR DESCRIPTION
I think this actually allows `date-fns` to be tree-shaked, and it was also causing problems in bundled builds due to the require (parcel probably wasn't looking at the `modules` field in the package.json).

The rest of the codebase is still using `require()`, and I can change those over to `import` too so we don't get into this issue again.