### PR TITLE
@radspec: add fallback to Parity on-chain signature registry

### DIFF
--- a/src/data/knownFunctions.js
+++ b/src/data/knownFunctions.js
@@ -1,7 +1,6 @@
 module.exports = {
-    "setOwner(address)": "Set `$1` as the new owner",
-    "setOwner(bytes32,address)": "Set `$2` as the new owner of the `$1` node",
-    "transfer(address,address,uint256)": "Transfer `@tokenAmount($1, $3)` to `$2`",
-    "payday()": "Get owed Payroll allowance",
-    "isForwarder()": "Very important action"
+  'setOwner(address)': 'Set `$1` as the new owner',
+  'setOwner(bytes32,address)': 'Set `$2` as the new owner of the `$1` node',
+  'transfer(address,address,uint256)': 'Transfer `@tokenAmount($1, $3)` to `$2`',
+  'payday()': 'Get owed Payroll allowance'
 }

--- a/src/defaults.js
+++ b/src/defaults.js
@@ -1,0 +1,3 @@
+module.exports = {
+  DEFAULT_ETH_NODE: 'wss://mainnet.eth.aragon.network/ws'
+}

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -8,6 +8,7 @@ const Web3Utils = require('web3-utils')
 const BN = require('bn.js')
 const types = require('../types')
 const { Helpers } = require('../helpers')
+const { DEFAULT_ETH_NODE } = require('../defaults')
 
 /**
  * A value coupled with a type
@@ -61,7 +62,7 @@ class Evaluator {
   constructor (ast, bindings, { ethNode, to, eth } = {}) {
     this.ast = ast
     this.bindings = bindings
-    this.eth = eth || new Eth(ethNode || 'https://mainnet.infura.io')
+    this.eth = eth || new Eth(ethNode || DEFAULT_ETH_NODE)
     this.to = to && new TypedValue('address', to)
     this.helpers = new Helpers(this.eth)
   }

--- a/src/helpers/lib/methodRegistry.js
+++ b/src/helpers/lib/methodRegistry.js
@@ -36,7 +36,7 @@ class MethodRegistry {
     this.network = opts.network || '1'
   }
 
-  // THIS FUNCTION CAN MUTATE THIS.ETH!
+  // !!! This function can mutate `this.eth`
   async initRegistry () {
     if (await this.eth.net.getId() !== '1') {
       this.eth = new Eth(DEFAULT_ETH_NODE)
@@ -60,7 +60,7 @@ class MethodRegistry {
   }
 
   parse (signature) {
-    // TODO: Throw if there are unknown types in the signature or there is any data after the closing parenthesis
+    // TODO: Throw if there are unknown types in the signature or there if is any chars after the closing parenthesis
     let name = signature.match(/^.+(?=\()/)[0]
     name = name.charAt(0).toUpperCase() + name.slice(1)
       .split(/(?=[A-Z])/).join(' ')

--- a/src/helpers/lib/methodRegistry.js
+++ b/src/helpers/lib/methodRegistry.js
@@ -26,6 +26,7 @@ const REGISTRY_LOOKUP_ABI = [
   }
 ]
 
+// networkId -> registry address
 const REGISTRY_MAP = {
   1: '0x44691B39d1a75dC4E0A0346CBB15E310e6ED1E86'
 }

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -174,23 +174,30 @@ const dataDecodeCases = [
     source: 'Perform action: `@radspec(addr, data)`',
     bindings: {
       addr: address(),
-      data: bytes('0x13af40350000000000000000000000000000000000000000000000000000000000000002') // setOwner(address)
+      data: bytes('0x13af40350000000000000000000000000000000000000000000000000000000000000002') // setOwner(address), on knownFunctions
     }
   }, 'Perform action: Set 0x0000000000000000000000000000000000000002 as the new owner'],
   [{
     source: '`@radspec(addr, data)`!',
     bindings: {
       addr: address(),
-      data: bytes('0x6881385b') // payday()
+      data: bytes('0x6881385b') // payday(), on knownFunctions
     }
   }, 'Get owed Payroll allowance!'],
+  [{
+    source: 'Cast a `@radspec(addr, data)`',
+    bindings: {
+      addr: address(),
+      data: bytes('0xdf133bca') // vote(uint256,bool,bool), from on-chain registry
+    }
+  }, 'Cast a Vote'],
   [{
     source: 'Perform action: `@radspec(addr, data)`',
     bindings: {
       addr: address(),
       data: bytes('0x12345678') // random signature
     }
-  }, 'Perform action: Unknown (0x12345678)']
+  }, 'Perform action: Unknown function (0x12345678)']
 ]
 
 const cases = [


### PR DESCRIPTION
When a function signature is not found on the local `knownFunctions.js` file, it checks Parity's [signature-registry](https://github.com/parity-contracts/signature-registry) to try to get the function name, which is what Metamask currently does for showing the function name in their signer.