### PR TITLE
Expose user helpers into evaluatorOptions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -3,4 +3,5 @@
 This is a list of examples using radspec.
 
 - [Basic](basic): Perform some basic math in a radspec expression and evaluate it with a transaction.
+- [User Helpers](user-helpers): Use custom functions in randspec expressions.
 - [Web3 Calls](web3-calls): Showcasing radspec's support for calls to external contracts

--- a/examples/user-helpers/index.js
+++ b/examples/user-helpers/index.js
@@ -1,0 +1,37 @@
+const radspec = require('../../src')
+const web3 = require('web3-utils')
+
+const expression = '`@toUtf8(gretting)` world.'
+const call = {
+  abi: [
+    {
+      name: 'sayHi',
+      constant: false,
+      type: 'function',
+      inputs: [
+        {
+          name: 'gretting',
+          type: 'bytes'
+        }
+      ],
+      outputs: []
+    }
+  ],
+  transaction: {
+    data: '0x2e8dedd00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000548656c6c6f000000000000000000000000000000000000000000000000000000'
+  }
+}
+const options = {
+  userHelpers: {
+    toUtf8: () => async (hex) => {
+      return {
+        type: 'string',
+        value: web3.toUtf8(hex)
+      }
+    }
+  }
+}
+
+radspec.evaluate(expression, call, options)
+  .then(console.log) // => "Hello world."
+  .catch(console.error)

--- a/test/scanner/identifiers.js
+++ b/test/scanner/identifiers.js
@@ -7,7 +7,7 @@ test('Scanner: types', async (t) => {
     ['`b`', ['TICK', { type: 'IDENTIFIER', value: 'b' }, 'TICK']],
     ['`test0123`', ['TICK', { type: 'IDENTIFIER', value: 'test0123' }, 'TICK']],
     ['`_hidden`', ['TICK', { type: 'IDENTIFIER', value: '_hidden' }, 'TICK']],
-    ['`$var0`', ['TICK', { type: 'IDENTIFIER', value: '$var0' }, 'TICK']],
+    ['`$var0`', ['TICK', { type: 'IDENTIFIER', value: '$var0' }, 'TICK']]
   ]
   t.plan(cases.length)
 


### PR DESCRIPTION
In this way, we can define custom helper functions. Example:

```js
const radspec = require('../../src')
const web3 = require('web3-utils')

const expression = '`@toUtf8(gretting)` world.'
const bindings = {
  gretting: {
    type: 'bytes',
    value: '0x48656c6c6f'
  }
}
const options = {
  userHelpers: {
    toUtf8: () => async (hex) => {
      return {
        type: 'string',
        value: web3.toUtf8(hex)
      }
    }
  }
}

radspec.evaluateRaw(expression, bindings, options)
  .then(console.log) // => "Hello world."
  .catch(console.error)
```