### PR TITLE
fix: interpolate self outside of just CallExpressions

### DIFF
--- a/src/data/knownFunctions.js
+++ b/src/data/knownFunctions.js
@@ -1,6 +1,6 @@
 module.exports = {
   'setOwner(address)': 'Set `$1` as the new owner',
   'setOwner(bytes32,address)': 'Set `$2` as the new owner of the `$1` node',
-  'transfer(address,address,uint256)': 'Transfer `@tokenAmount($1, $3)` to `$2`',
+  'transfer(address,uint256)': 'Transfer `@tokenAmount(self, $2)` to `$1`',
   'payday()': 'Get owed Payroll allowance'
 }

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -222,15 +222,6 @@ class Evaluator {
       return leftFalsey ? this.evaluateNode(node.right) : left
     }
 
-    if (node.type === 'Identifier') {
-      if (!this.bindings.hasOwnProperty(node.value)) {
-        this.panic(`Undefined binding "${node.value}"`)
-      }
-
-      const binding = this.bindings[node.value]
-      return new TypedValue(binding.type, binding.value)
-    }
-
     if (node.type === 'CallExpression') {
       // TODO Add a check for number of return values (can only be 1 for now)
       let target
@@ -280,6 +271,19 @@ class Evaluator {
       const result = await this.helpers.execute(helperName, inputs)
 
       return new TypedValue(result.type, result.value)
+    }
+
+    if (node.type === 'Identifier') {
+      if (node.value === 'self') {
+        return this.to
+      }
+
+      if (!this.bindings.hasOwnProperty(node.value)) {
+        this.panic(`Undefined binding "${node.value}"`)
+      }
+
+      const binding = this.bindings[node.value]
+      return new TypedValue(binding.type, binding.value)
     }
   }
 

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -178,12 +178,19 @@ const dataDecodeCases = [
     }
   }, 'Perform action: Set 0x0000000000000000000000000000000000000002 as the new owner'],
   [{
-    source: '`@radspec(addr, data)`!',
+    source: 'Payroll: `@radspec(addr, data)`!',
     bindings: {
       addr: address(),
       data: bytes('0x6881385b') // payday(), on knownFunctions
     }
-  }, 'Get owed Payroll allowance!'],
+  }, 'Payroll: Get owed Payroll allowance!'],
+  [{
+    source: 'Transfer: `@radspec(addr, data)`',
+    bindings: {
+      addr: address('0x960b236a07cf122663c4303350609a66a7b288c0'),
+      data: bytes('0xa9059cbb00000000000000000000000031ab1f92344e3277ce9404e4e097dab7514e6d2700000000000000000000000000000000000000000000000821ab0d4414980000') // transfer(), on knownFunctions requiring helpers
+    }
+  }, 'Transfer: Transfer 150 ANT to 0x31AB1f92344e3277ce9404E4e097dab7514E6D27'],
   [{
     source: 'Cast a `@radspec(addr, data)`',
     bindings: {


### PR DESCRIPTION
Fixes #59, builds on #55.

Allows `self` to be interpolated as a normal identifier.