### PR TITLE
 fix: Remove circular dependency and dynamic require for meta radspec

### DIFF
--- a/src/data/knownFunctions.js
+++ b/src/data/knownFunctions.js
@@ -1,6 +1,6 @@
 module.exports = {
   'setOwner(address)': 'Set `$1` as the new owner',
   'setOwner(bytes32,address)': 'Set `$2` as the new owner of the `$1` node',
-  'transfer(address,address,uint256)': 'Transfer `@tokenAmount($1, $3)` to `$2`',
+  'transfer(address,uint256)': 'Transfer `@tokenAmount(self, $2)` to `$1`',
   'payday()': 'Get owed Payroll allowance'
 }

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -222,15 +222,6 @@ class Evaluator {
       return leftFalsey ? this.evaluateNode(node.right) : left
     }
 
-    if (node.type === 'Identifier') {
-      if (!this.bindings.hasOwnProperty(node.value)) {
-        this.panic(`Undefined binding "${node.value}"`)
-      }
-
-      const binding = this.bindings[node.value]
-      return new TypedValue(binding.type, binding.value)
-    }
-
     if (node.type === 'CallExpression') {
       // TODO Add a check for number of return values (can only be 1 for now)
       let target
@@ -280,6 +271,19 @@ class Evaluator {
       const result = await this.helpers.execute(helperName, inputs)
 
       return new TypedValue(result.type, result.value)
+    }
+
+    if (node.type === 'Identifier') {
+      if (node.value === 'self') {
+        return this.to
+      }
+
+      if (!this.bindings.hasOwnProperty(node.value)) {
+        this.panic(`Undefined binding "${node.value}"`)
+      }
+
+      const binding = this.bindings[node.value]
+      return new TypedValue(binding.type, binding.value)
     }
   }
 

--- a/src/helpers/HelperManager.js
+++ b/src/helpers/HelperManager.js
@@ -1,0 +1,51 @@
+/**
+ * @module radspec/helpers/HelperManager
+ */
+
+/**
+ * Class for managing the execution of helper functions
+ *
+ * @class HelperManager
+ * @param {Object} availableHelpers Defined helpers
+ */
+class HelperManager {
+  constructor (availableHelpers = {}) {
+    this.availableHelpers = availableHelpers
+  }
+
+  /**
+   * Does a helper exist
+   *
+   * @param  {string} helper Helper name
+   * @return {bool}
+   */
+  exists (helper) {
+    return !!this.availableHelpers[helper]
+  }
+
+  /**
+   * Execute a helper with some inputs
+   *
+   * @param  {string} helper Helper name
+   * @param  {Array<radspec/evaluator/TypedValue>} inputs
+   * @param  {Object} config Configuration for running helper
+   * @param  {Web3}                        config.eth Web3 instance
+   * @param  {radspec/evaluator/Evaluator} config.evaluator Current evaluator
+   * @return {Promise<radspec/evaluator/TypedValue>}
+   */
+  execute (helper, inputs, { eth, evaluator }) {
+    inputs = inputs.map(input => input.value) // pass values directly
+    return this.availableHelpers[helper](eth, evaluator)(...inputs)
+  }
+
+  /**
+   * Get all registered helpers as a key-value mapping
+   *
+   * @return {Object}
+   */
+  getHelpers () {
+    return this.availableHelpers
+  }
+}
+
+module.exports = HelperManager

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -1,3 +1,4 @@
+const HelperManager = require('./HelperManager')
 const formatDate = require('./formatDate')
 const echo = require('./echo')
 const tokenAmount = require('./tokenAmount')
@@ -14,44 +15,14 @@ const defaultHelpers = {
   echo
 }
 
-/**
- * Class for managing the execution of helper functions
- *
- * @class Helpers
- * @param {web3/eth} eth web3.eth instance
- * @param {Object.<string,helpers/Helper>} userHelpers User defined helpers
- */
-class Helpers {
-  constructor (eth, userHelpers = {}) {
-    this.eth = eth
-    this.availableHelpers = { ...defaultHelpers, ...userHelpers }
-  }
-
-  /**
-   * Does a helper exist
-   *
-   * @param  {string} helper Helper name
-   * @return {bool}
-   */
-  exists (helper) {
-    return !!this.availableHelpers[helper]
-  }
-
-  /**
-   * Execute a helper with some inputs
-   *
-   * @param  {string} helper Helper name
-   * @param  {Array<radspec/evaluator/TypedValue>} inputs
-   * @return {Promise<radspec/evaluator/TypedValue>}
-   */
-  execute (helper, inputs) {
-    inputs = inputs.map(input => input.value) // pass values directly
-    return this.availableHelpers[helper](this.eth)(...inputs)
-  }
-}
-
 module.exports = {
-  Helpers,
+  HelperManager,
+  defaultHelpers,
 
-  ...defaultHelpers
+  echo,
+  formatDate,
+  formatPct,
+  radspec,
+  transformTime,
+  tokenAmount,
 }

--- a/src/helpers/index.js
+++ b/src/helpers/index.js
@@ -24,5 +24,5 @@ module.exports = {
   formatPct,
   radspec,
   transformTime,
-  tokenAmount,
+  tokenAmount
 }

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,0 +1,27 @@
+const evaluator = require('../evaluator')
+const parser = require('../parser')
+const scanner = require('../scanner')
+
+/**
+ * Evaluate a radspec expression with manual bindings.
+ *
+ * @example
+ * const radspec = require('radspec')
+ *
+ * radspec.evaluateRaw('a is `a`', {
+ *   a: { type: 'int256', value: 10 }
+ * }).then(console.log)
+ * @param  {string} source The radspec expression
+ * @param  {Bindings} bindings An object of bindings and their values
+ * @param {?Object} evaluatorOptions An options object for the evaluator (see Evaluator)
+ * @return {Promise<string>} The result of the evaluation
+ */
+function evaluateRaw (source, bindings, evaluatorOptions) {
+  return scanner.scan(source)
+    .then(parser.parse)
+    .then((ast) => evaluator.evaluate(ast, bindings, evaluatorOptions))
+}
+
+module.exports = {
+  evaluateRaw,
+}

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -23,5 +23,5 @@ function evaluateRaw (source, bindings, evaluatorOptions) {
 }
 
 module.exports = {
-  evaluateRaw,
+  evaluateRaw
 }

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -178,12 +178,19 @@ const dataDecodeCases = [
     }
   }, 'Perform action: Set 0x0000000000000000000000000000000000000002 as the new owner'],
   [{
-    source: '`@radspec(addr, data)`!',
+    source: 'Payroll: `@radspec(addr, data)`!',
     bindings: {
       addr: address(),
       data: bytes('0x6881385b') // payday(), on knownFunctions
     }
-  }, 'Get owed Payroll allowance!'],
+  }, 'Payroll: Get owed Payroll allowance!'],
+  [{
+    source: 'Transfer: `@radspec(addr, data)`',
+    bindings: {
+      addr: address('0x960b236a07cf122663c4303350609a66a7b288c0'),
+      data: bytes('0xa9059cbb00000000000000000000000031ab1f92344e3277ce9404e4e097dab7514e6d2700000000000000000000000000000000000000000000000821ab0d4414980000') // transfer(), on knownFunctions requiring helpers
+    }
+  }, 'Transfer: Transfer 150 ANT to 0x31AB1f92344e3277ce9404E4e097dab7514E6D27'],
   [{
     source: 'Cast a `@radspec(addr, data)`',
     bindings: {

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -1,6 +1,7 @@
 const test = require('ava')
 const BN = require('bn.js')
-const { evaluateRaw } = require('../../src')
+const { evaluateRaw } = require('../../src/lib')
+const { defaultHelpers } = require('../../src/helpers')
 const { tenPow } = require('../../src/helpers/lib/formatBN')
 const { ETH } = require('../../src/helpers/lib/token')
 
@@ -310,7 +311,14 @@ const cases = [
 
 cases.forEach(([input, expected], index) => {
   test(`${index} - ${input.source}`, async (t) => {
-    const actual = await evaluateRaw(input.source, input.bindings, input.options)
+    const actual = await evaluateRaw(
+      input.source,
+      input.bindings,
+      {
+        ...input.options,
+        availableHelpers: defaultHelpers,
+      }
+    )
     t.is(
       actual,
       expected,


### PR DESCRIPTION
Builds on #62, #55.

Moves a few things around so the `@radspec` helper doesn't cause a circular dependency (unblocks #61).

Was looking into dynamic import instead of this but couldn't get it working with babel and it looked like parcel didn't support it very well anyway 🤷‍♂️.