### PR TITLE
Upgrade web3.js for latest node.js (<11) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "@babel/runtime": "^7.1.2",
     "bn.js": "4.11.6",
     "date-fns": "2.0.0-alpha.22",
-    "web3-eth": "1.2.1",
-    "web3-eth-abi": "1.2.1",
-    "web3-utils": "1.2.1"
+    "web3-eth": "^1.2.1",
+    "web3-eth-abi": "^1.2.1",
+    "web3-utils": "^1.2.1"
   },
   "ava": {
     "require": [

--- a/package.json
+++ b/package.json
@@ -47,9 +47,9 @@
     "@babel/runtime": "^7.1.2",
     "bn.js": "4.11.6",
     "date-fns": "2.0.0-alpha.22",
-    "web3-eth": "1.0.0-beta.33",
-    "web3-eth-abi": "1.0.0-beta.33",
-    "web3-utils": "1.0.0-beta.33"
+    "web3-eth": "1.2.1",
+    "web3-eth-abi": "1.2.1",
+    "web3-utils": "1.2.1"
   },
   "ava": {
     "require": [

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -251,7 +251,10 @@ export class Evaluator {
 
         inputs: inputs.map(({ type }) => ({
           type,
-          // web3.js requires the inputs to have names, otherwise it assumes the type is a tuple
+          // web3.js 1.x requires the inputs to have names, otherwise it assumes the type is a tuple
+          // We can remove this if web3.js 1.x fixes this, or we upgrade to a newer major version
+          // For reference: this is the problematic bit in web3.js:
+          // https://github.com/ethereum/web3.js/blob/7d1b0eab31ff6b52c170dedc172decebea0a0217/packages/web3-eth-abi/src/index.js#L110
           name: 'nonEmptyName'
         })),
         outputs

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -249,7 +249,11 @@ export class Evaluator {
         name: node.callee,
         type: 'function',
 
-        inputs,
+        inputs: inputs.map(({ type }) => ({
+          type,
+          // web3.js requires the inputs to have names, otherwise it assumes the type is a tuple
+          name: 'nonEmptyName'
+        })),
         outputs
       }, inputs.map((input) => input.value))
 


### PR DESCRIPTION
The scrypt packages which is a dependency of web3-eth (and others) does not work with node.js >=11.15. This issue is already solved in https://github.com/ethereum/web3.js/pull/2938, so theoretically it should be sufficient to just update web3 to the latest 1.x version (which happens in this pull-request). Unfortunately, after this update, some of the tests fail :(

I did not have time to find the root cause of this, but just wanted to inform about my failing attempt.

Maybe in the meantime, add something like this to package.json?

```json
    "engines": {
        "node": ">=8.0.0 <=11.15.0"
    },
```

I can confirm that it works with Node.js@10.16.3 (LTS)