### PR TITLE
msg sender and value bindings

### DIFF
--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -61,11 +61,13 @@ class TypedValue {
  * @property {radspec/Bindings} bindings
  */
 export class Evaluator {
-  constructor (ast, bindings, { availableHelpers = {}, eth, ethNode, to } = {}) {
+  constructor (ast, bindings, { availableHelpers = {}, eth, ethNode, from, to, value = '0' } = {}) {
     this.ast = ast
     this.bindings = bindings
     this.eth = eth || new Eth(ethNode || DEFAULT_ETH_NODE)
+    this.from = from && new TypedValue('address', from)
     this.to = to && new TypedValue('address', to)
+    this.value = new TypedValue('uint', new BN(value))
     this.helpers = new HelperManager(availableHelpers)
   }
 
@@ -291,6 +293,18 @@ export class Evaluator {
       )
 
       return new TypedValue(result.type, result.value)
+    }
+
+    if (node.type === 'PropertyAccessExpression' && node.target.value === 'msg') {
+      if (node.property === 'value') {
+        return this.value
+      }
+
+      if (node.property === 'sender') {
+        return this.from
+      }
+
+      this.panic(`Expecting value or sender property for msg identifier but got: ${node.property}`)
     }
 
     if (node.type === 'Identifier') {

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -61,13 +61,14 @@ class TypedValue {
  * @property {radspec/Bindings} bindings
  */
 export class Evaluator {
-  constructor (ast, bindings, { availableHelpers = {}, eth, ethNode, from, to, value = '0' } = {}) {
+  constructor (ast, bindings, { availableHelpers = {}, eth, ethNode, from, to, value = '0', data } = {}) {
     this.ast = ast
     this.bindings = bindings
     this.eth = eth || new Eth(ethNode || DEFAULT_ETH_NODE)
     this.from = from && new TypedValue('address', from)
     this.to = to && new TypedValue('address', to)
     this.value = new TypedValue('uint', new BN(value))
+    this.data = data && new TypedValue('bytes', data)
     this.helpers = new HelperManager(availableHelpers)
   }
 
@@ -304,7 +305,11 @@ export class Evaluator {
         return this.from
       }
 
-      this.panic(`Expecting value or sender property for msg identifier but got: ${node.property}`)
+      if (node.property === 'data') {
+        return this.data
+      }
+
+      this.panic(`Expecting value, sender or data property for msg identifier but got: ${node.property}`)
     }
 
     if (node.type === 'Identifier') {

--- a/src/index.js
+++ b/src/index.js
@@ -81,6 +81,9 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
 
   const availableHelpers = { ...defaultHelpers, ...userHelpers }
 
+  // Get additional options
+  const { from, to, value } = call.transaction
+
   // Evaluate expression with bindings from the transaction data
   return evaluateRaw(
     source,
@@ -88,7 +91,9 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
     {
       ...options,
       availableHelpers,
-      to: call.transaction.to
+      from,
+      to,
+      value
     }
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -81,8 +81,9 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
 
   const availableHelpers = { ...defaultHelpers, ...userHelpers }
 
+  console.log('call tx', call.transaction)
   // Get additional options
-  const { from, to, value } = call.transaction
+  const { from, to, value, data } = call.transaction
 
   // Evaluate expression with bindings from the transaction data
   return evaluateRaw(
@@ -93,7 +94,8 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
       availableHelpers,
       from,
       to,
-      value
+      value,
+      data
     }
   )
 }

--- a/src/index.js
+++ b/src/index.js
@@ -81,7 +81,6 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
 
   const availableHelpers = { ...defaultHelpers, ...userHelpers }
 
-  console.log('call tx', call.transaction)
   // Get additional options
   const { from, to, value, data } = call.transaction
 

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -379,6 +379,19 @@ const cases = [
     options: { to: '0xf562B25Db6e707694ceC3A4908dC58fF6bDABa40' },
   }, 'Explicit (first type): 0'],
 
+  // msg.value and msg.sender options
+  [{
+    source:"No value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `reciever`",
+    bindings: { token: address(ETH), reciever:  address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb') },
+    options: { from: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7'},
+  }, 'No value: Send 0 ETH from 0xb4124cEB3451635DAcedd11767f004d8a28c6eE7 to 0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb'],
+
+  [{
+    source:"With value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `reciever`",
+    bindings: { token: address(ETH), reciever:  address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb') },
+    options: { from: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7', value: '1000000000000000000' },
+  }, 'With value: Send 1 ETH from 0xb4124cEB3451635DAcedd11767f004d8a28c6eE7 to 0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb'],
+
   ...comparisonCases,
   ...helperCases,
   ...dataDecodeCases

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -4,6 +4,8 @@ import { evaluateRaw } from '../../src/lib'
 import { defaultHelpers } from '../../src/helpers'
 import { tenPow } from '../../src/helpers/lib/formatBN'
 import { ETH } from '../../src/helpers/lib/token'
+import knownFunctions from '../../src/data/knownFunctions'
+import { keccak256 } from 'web3-utils'
 
 const int = (value) => ({
   type: 'int256',
@@ -379,18 +381,31 @@ const cases = [
     options: { to: '0xf562B25Db6e707694ceC3A4908dC58fF6bDABa40' },
   }, 'Explicit (first type): 0'],
 
-  // msg.value and msg.sender options
+  // msg.(sender | value | data) options
   [{
-    source:"No value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `reciever`",
-    bindings: { token: address(ETH), reciever:  address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb') },
+    source: "No value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `receiver`",
+    bindings: { token: address(ETH), receiver:  address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb') },
     options: { from: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7'},
   }, 'No value: Send 0 ETH from 0xb4124cEB3451635DAcedd11767f004d8a28c6eE7 to 0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb'],
 
   [{
-    source:"With value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `reciever`",
-    bindings: { token: address(ETH), reciever:  address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb') },
+    source: "With value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `receiver`",
+    bindings: { token: address(ETH), receiver:  address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb') },
     options: { from: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7', value: '1000000000000000000' },
   }, 'With value: Send 1 ETH from 0xb4124cEB3451635DAcedd11767f004d8a28c6eE7 to 0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb'],
+
+  [{
+    source: "Sending tx with data `msg.data` to contract at `contract`",
+    bindings: { contract: address('0x960b236A07cf122663c4303350609A66A7B288C0') },
+    options: { data: '0xabcdef'}
+  }, "Sending tx with data 0xabcdef to contract at 0x960b236A07cf122663c4303350609A66A7B288C0"],
+  
+  // using msg.data on a helper
+  [{
+    source: "Performs a call to `@radspec(contract, msg.data)`",
+    bindings: { contract: address('0x960b236A07cf122663c4303350609A66A7B288C0') },
+    options: { data: keccak256(Object.keys(knownFunctions)[3]).slice(0,10) }
+  }, `Performs a call to ${Object.values(knownFunctions)[3]}`],
 
   ...comparisonCases,
   ...helperCases,


### PR DESCRIPTION
closes #80 

- Passed tx sender and value to evaluator options

- Added check for `msg.sender` and `msg.value` as  a `PropertyAccessExpression`

Example of the syntax: 
```
Send `@tokenAmount(token, msg.value)` from `msg.sender` to `reciever`
```

where 
```
token = address(0)
```