### PR TITLE
chore: unpin bn.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "bn.js": "4.11.6",
+    "bn.js": "^4.11.8",
     "date-fns": "2.0.0-alpha.22",
     "web3-eth": "^1.2.1",
     "web3-eth-abi": "^1.2.1",


### PR DESCRIPTION
Forgot to do this earlier, when we upgraded to the latest `web3.js@1`.

`web3.js` has stopped pinning it, so we should as well to avoid duplicate dependencies.