### PR TITLE
 * feat: add dcl known functions to @radspec helper

### DIFF
--- a/src/data/decentraland/knownFunctions.js
+++ b/src/data/decentraland/knownFunctions.js
@@ -1,8 +1,4 @@
 export default {
-  'setOwner(address)': 'Set `$1` as the new owner',
-  'setOwner(bytes32,address)': 'Set `$2` as the new owner of the `$1` node',
-  'transfer(address,uint256)': 'Transfer `@tokenAmount(self, $2)` to `$1`',
-  'payday()': 'Get owed Payroll allowance',
   'setOwnerCutPerMillion(uint256)': 'Set marketplace fees to `$1 / 1000000`%',
   'transferMarketplaceOwnership(address)':
     'Transfer ownership of the marketplace to `$1`',

--- a/src/data/decentraland/knownFunctions.js
+++ b/src/data/decentraland/knownFunctions.js
@@ -1,0 +1,12 @@
+export default {
+  'setOwner(address)': 'Set `$1` as the new owner',
+  'setOwner(bytes32,address)': 'Set `$2` as the new owner of the `$1` node',
+  'transfer(address,uint256)': 'Transfer `@tokenAmount(self, $2)` to `$1`',
+  'payday()': 'Get owed Payroll allowance',
+  'setOwnerCutPerMillion(uint256)': 'Set marketplace fees to `$1 / 1000000`%',
+  'transferMarketplaceOwnership(address)':
+    'Transfer ownership of the marketplace to `$1`',
+  'transferOwnership(address)': 'Transfer ownership of the contract to `$1`',
+  'pause()': 'Pause contract',
+  'unpause()': 'Unpause Contract`'
+}

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,0 +1,7 @@
+import dclKnownFunctions from './decentraland/knownFunctions'
+import baseKnownFunctions from './knownFunctions'
+
+export const knownFunctions = {
+  ...dclKnownFunctions,
+  ...baseKnownFunctions
+}

--- a/src/helpers/radspec.js
+++ b/src/helpers/radspec.js
@@ -2,7 +2,7 @@ import ABI from 'web3-eth-abi'
 import { keccak256 } from 'web3-utils'
 import MethodRegistry from './lib/methodRegistry'
 import { evaluateRaw } from '../lib/'
-import knownFunctions from '../data/knownFunctions'
+import { knownFunctions } from '../data/'
 
 const makeUnknownFunctionNode = (methodId) => ({
   type: 'string',

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -226,6 +226,13 @@ const dataDecodeCases = [
     }
   }, 'Payroll: Get owed Payroll allowance!'],
   [{
+    source: 'Decentraland: `@radspec(addr, data)`',
+    bindings: {
+      addr: address(),
+      data: bytes('0x1206dc5f00000000000000000000000031ab1f92344e3277ce9404e4e097dab7514e6d27') // transferMarketplaceOwnership(), on decentraland's knownFunctions
+    }
+  }, 'Decentraland: Transfer ownership of the marketplace to 0x31AB1f92344e3277ce9404E4e097dab7514E6D27'],
+  [{
     source: 'Transfer: `@radspec(addr, data)`',
     bindings: {
       addr: address('0x960b236a07cf122663c4303350609a66a7b288c0'),


### PR DESCRIPTION
I have added some functions to be tested by the agent.

```js
'setOwnerCutPerMillion(uint256)': 'Set marketplace fees to `$1 / 1000000`%',
  'transferMarketplaceOwnership(address)':
    'Transfer ownership of the marketplace to `$1`',
  'transferOwnership(address)': 'Transfer ownership of the contract to `$1`',
  'pause()': 'Pause contract',
  'unpause()': 'Unpause Contract`'
```