### PR TITLE
Ethers refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ and
 }]
 ```
 
+Note you can also use [Human-Redable abis](https://blog.ricmoo.com/human-readable-contract-abis-in-ethers-js-141902f4d917). For the above example that would be:
+
+```json
+["function setAge(uint256 numYears) public view"]
+```
+---
+
 Write a simple tool using radspec to interpret this:
 
 ```js
@@ -87,6 +94,8 @@ const call = {
 radspec.evaluate(expression, call)
   .then(console.log) // => "Set the tree age to 10 years"
 ```
+
+or
 
 See more examples [here](examples) and in the [tests](test/examples/examples.js).
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -53,12 +53,14 @@ Evaluate a radspec expression (`source`) for a transaction (`call`)
 
 -   `source` **[string][7]** The radspec expression
 -   `call` **[Object][6]** The call that determines the bindings for this evaluation
-    -   `call.abi` **[Array][11]** The ABI used to decode the transaction data
+    -   `call.abi` **[Array][11]** The ABI used to decode the transaction data. Support [JSON and Human-Redable formats][13].
     -   `call.transaction` **[Object][6]** The transaction to decode for this evaluation
         -   `call.transaction.to` **[string][7]** The destination address for this transaction
         -   `call.transaction.data` **[string][7]** The transaction data
 -   `options` **[Object][6]?** An options object (optional, default `{}`)
     -   `options.ethNode` **[string][7]?** The URL to an Ethereum node
+    -   `options.provider` **[ethers.providers.Provider][12]?** Ethers provider
+    -   `options.userHelpers` **[Object]?** User defined helpers
 
 **Examples**
 
@@ -67,18 +69,7 @@ import radspec from 'radspec'
 
 const expression = 'Will multiply `a` by 7 and return `a * 7`.'
 const call = {
-  abi: [{
-    name: 'multiply',
-    constant: false,
-    type: 'function',
-    inputs: [{
-      name: 'a',
-      type: 'uint256'
-    }],
-    outputs: [{
-      name: 'd',
-      type: 'uint256'
-    }]
+  abi: ['function multiply(uint256 a) public view returns(uint256)']
   }],
   transaction: {
     to: '0x8521742d3f456bd237e312d6e30724960f72517a',
@@ -113,3 +104,7 @@ Returns **[Promise][10]&lt;[string][7]>** The result of the evaluation
 [10]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Promise
 
 [11]: https://developer.mozilla.org/docs/Web/JavaScript/Reference/Global_Objects/Array
+
+[12]: https://docs-beta.ethers.io/api/providers/provider/
+
+[13]: https://docs-beta.ethers.io/api/utils/abi/interface/#Interface--creating-instances

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,4 +4,4 @@ This is a list of examples using radspec.
 
 - [Basic](basic): Perform some basic math in a radspec expression and evaluate it with a transaction.
 - [User Helpers](user-helpers): Use custom functions in randspec expressions.
-- [Web3 Calls](web3-calls): Showcasing radspec's support for calls to external contracts
+- [Contract Calls](contract-calls): Showcasing radspec's support for calls to external contracts

--- a/examples/basic/index.js
+++ b/examples/basic/index.js
@@ -2,19 +2,7 @@ import * as radspec from '../../src'
 
 const expression = 'Will multiply `a` by 7 and return `a * 7`.'
 const call = {
-  abi: [{
-    name: 'multiply',
-    constant: false,
-    type: 'function',
-    inputs: [{
-      name: 'a',
-      type: 'uint256'
-    }],
-    outputs: [{
-      name: 'd',
-      type: 'uint256'
-    }]
-  }],
+  abi: ['function multiply(uint256 a) public view returns(uint256)'],
   transaction: {
     data: '0xc6888fa1000000000000000000000000000000000000000000000000000000000000007a'
   }

--- a/examples/contract-calls/index.js
+++ b/examples/contract-calls/index.js
@@ -4,19 +4,7 @@ const expressions = [
   {
     expression: 'Allocate `_amount _token.symbol(): string`.',
     call: {
-      abi: [{
-        name: 'allocate',
-        constant: false,
-        type: 'function',
-        inputs: [{
-          name: '_token',
-          type: 'address'
-        }, {
-          name: '_amount',
-          type: 'uint256'
-        }],
-        outputs: []
-      }],
+      abi: ['function allocate(address _token, uint256 _amount) public view'],
       transaction: {
         data: '0xb78b52df000000000000000000000000960b236a07cf122663c4303350609a66a7b288c00000000000000000000000000000000000000000000000000000000000000064'
       }
@@ -25,19 +13,7 @@ const expressions = [
   {
     expression: 'Send `_amount` wei to `(_token.controller(): address).sale(): address` to buy `_token.symbol(): string`',
     call: {
-      abi: [{
-        name: 'allocate',
-        constant: false,
-        type: 'function',
-        inputs: [{
-          name: '_token',
-          type: 'address'
-        }, {
-          name: '_amount',
-          type: 'uint256'
-        }],
-        outputs: []
-      }],
+      abi: ['function allocate(address _token, uint256 _amount) public view'],
       transaction: {
         data: '0xb78b52df000000000000000000000000960b236a07cf122663c4303350609a66a7b288c00000000000000000000000000000000000000000000000000000000000000064'
       }

--- a/examples/user-helpers/index.js
+++ b/examples/user-helpers/index.js
@@ -1,22 +1,10 @@
+import { ethers } from 'ethers'
+
 import * as radspec from '../../src'
-import web3Utils from 'web3-utils'
 
 const expression = '`@toUtf8(gretting)` world.'
 const call = {
-  abi: [
-    {
-      name: 'sayHi',
-      constant: false,
-      type: 'function',
-      inputs: [
-        {
-          name: 'gretting',
-          type: 'bytes'
-        }
-      ],
-      outputs: []
-    }
-  ],
+  abi: ['function sayHi(bytes gretting) public'],
   transaction: {
     data: '0x2e8dedd00000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000548656c6c6f000000000000000000000000000000000000000000000000000000'
   }
@@ -26,7 +14,7 @@ const options = {
     toUtf8: () => async (hex) => {
       return {
         type: 'string',
-        value: web3Utils.toUtf8(hex)
+        value: ethers.toUtf8String(hex)
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -35,22 +35,19 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.1.0",
     "@babel/preset-env": "^7.1.0",
-    "@babel/register": "^7.0.0",
-    "ava": "^1.0.0-rc.1",
+    "@babel/register": "^7.10.1",
+    "ava": "^3.8.2",
     "babel-eslint": "^10.0.1",
     "babel-preset-minify": "^0.5.0",
     "codecov": "^3.6.5",
-    "documentation": "^9.0.0-alpha.0",
+    "documentation": "^13.0.1",
     "nyc": "^14.1.1",
     "standard": "^12.0.1"
   },
   "dependencies": {
     "@babel/runtime": "^7.1.2",
-    "bn.js": "^4.11.8",
-    "date-fns": "2.0.0-alpha.22",
-    "web3-eth": "^1.2.1",
-    "web3-eth-abi": "^1.2.1",
-    "web3-utils": "^1.2.1"
+    "date-fns": "^2.0.0",
+    "ethers": "^5.0.0-beta.190"
   },
   "ava": {
     "require": [

--- a/src/helpers/HelperManager.js
+++ b/src/helpers/HelperManager.js
@@ -29,13 +29,13 @@ export default class HelperManager {
    * @param  {string} helper Helper name
    * @param  {Array<radspec/evaluator/TypedValue>} inputs
    * @param  {Object} config Configuration for running helper
-   * @param  {Web3}                        config.eth Web3 instance
+   * @param {?ethers.providers.Provider} config.provider Ethers provider
    * @param  {radspec/evaluator/Evaluator} config.evaluator Current evaluator
    * @return {Promise<radspec/evaluator/TypedValue>}
    */
-  execute (helper, inputs, { eth, evaluator }) {
-    inputs = inputs.map(input => input.value) // pass values directly
-    return this.availableHelpers[helper](eth, evaluator)(...inputs)
+  execute (helper, inputs, { provider, evaluator }) {
+    inputs = inputs.map((input) => input.value) // pass values directly
+    return this.availableHelpers[helper](provider, evaluator)(...inputs)
   }
 
   /**

--- a/src/helpers/formatPct.js
+++ b/src/helpers/formatPct.js
@@ -1,4 +1,4 @@
-import BN from 'bn.js'
+import { BigNumber } from 'ethers'
 import { formatBN, tenPow } from './lib/formatBN'
 
 export default () =>
@@ -11,11 +11,15 @@ export default () =>
    * @return {Promise<radspec/evaluator/TypedValue>}
    */
   async (value, base = tenPow(18), precision = 2) => {
-    const valueBn = new BN(value)
-    const baseBn = new BN(base)
+    const valueBn = BigNumber.from(value)
+    const baseBn = BigNumber.from(base)
 
     const oneHundred = tenPow(2)
-    const formattedAmount = formatBN(valueBn.mul(oneHundred), baseBn, Number(precision))
+    const formattedAmount = formatBN(
+      valueBn.mul(oneHundred),
+      baseBn,
+      Number(precision)
+    )
 
     return {
       type: 'string',

--- a/src/helpers/fromHex.js
+++ b/src/helpers/fromHex.js
@@ -1,19 +1,19 @@
-import { toUtf8, toDecimal, toAscii } from 'web3-utils'
+import { ethers, BigNumber } from 'ethers'
+
 export default () =>
   /**
    * Returns the string representation of a given hex value
    *
    * @param {string} hex The hex string
-   * @param {string} [to='utf8'] The type to convert the hex from (supported types: 'utf8', 'number', 'decimal')
+   * @param {string} [to='utf8'] The type to convert the hex from (supported types: 'utf8', 'bytes32', 'number')
    * @return {radspec/evaluator/TypedValue}
    */
-  (hex, to = 'utf8') =>
-    ({
-      type: 'string',
-      value:
-        to === 'utf8'
-          ? toUtf8(hex)
-          : to === 'ascii'
-            ? toAscii(hex)
-            : toDecimal(hex)
-    })
+  (hex, to = 'utf8') => ({
+    type: 'string',
+    value:
+      to === 'bytes32'
+        ? ethers.utils.parseBytes32String(hex)
+        : to === 'number'
+          ? BigNumber.from(hex).toNumber()
+          : ethers.utils.toUtf8String(hex)
+  })

--- a/src/helpers/lib/formatBN.js
+++ b/src/helpers/lib/formatBN.js
@@ -1,4 +1,4 @@
-import BN from 'bn.js'
+import { BigNumber } from 'ethers'
 
 function sameFraction (first, second) {
   // First remove any trailing zeros, since they're meaningless in fractions
@@ -10,12 +10,10 @@ function sameFraction (first, second) {
   // appending a one as the first digit.
   //
   // For example, .001 and .00100 are the same value, but .0001 and .001 are not.
-  return (new BN(`1${first}`).eq(new BN(`1${second}`)))
+  return BigNumber.from(`1${first}`).eq(BigNumber.from(`1${second}`))
 }
 
-export const tenPow = x => (
-  (new BN(10)).pow(new BN(x))
-)
+export const tenPow = (x) => BigNumber.from(10).pow(BigNumber.from(x))
 
 export const formatBN = (amount, base, precision, fixed = false) => {
   // Inspired by: https://github.com/ethjs/ethjs-unit/blob/35d870eae1c32c652da88837a71e252a63a83ebb/src/index.js#L83
@@ -27,9 +25,16 @@ export const formatBN = (amount, base, precision, fixed = false) => {
 
   fraction = `${zeros}${fraction}`
   const fractionWithoutTrailingZeros = fraction.replace(/0+$/, '')
-  const fractionAfterPrecision = (fixed ? fraction : fractionWithoutTrailingZeros).slice(0, precision)
+  const fractionAfterPrecision = (fixed
+    ? fraction
+    : fractionWithoutTrailingZeros
+  ).slice(0, precision)
 
-  if (!fixed && (fractionAfterPrecision === '' || parseInt(fractionAfterPrecision, 10) === 0)) {
+  if (
+    !fixed &&
+    (fractionAfterPrecision === '' ||
+      parseInt(fractionAfterPrecision, 10) === 0)
+  ) {
     return whole
   }
 

--- a/src/helpers/lib/methodRegistry.js
+++ b/src/helpers/lib/methodRegistry.js
@@ -1,29 +1,10 @@
 // From: https://github.com/danfinlay/eth-method-registry
+import { ethers } from 'ethers'
 
-import Eth from 'web3-eth'
 import { DEFAULT_ETH_NODE } from '../../defaults'
 
-/* eslint-disable key-spacing, quotes */
 const REGISTRY_LOOKUP_ABI = [
-  {
-    "constant": true,
-    "inputs": [
-      {
-        "name": "",
-        "type": "bytes4"
-      }
-    ],
-    "name": "entries",
-    "outputs":
-    [
-      {
-        "name": "",
-        "type": "string"
-      }
-    ],
-    "payable": false,
-    "type": "function"
-  }
+  'function entries(bytes4) public view returns (string)'
 ]
 
 // networkId -> registry address
@@ -33,14 +14,16 @@ const REGISTRY_MAP = {
 
 export default class MethodRegistry {
   constructor (opts = {}) {
-    this.eth = opts.eth || new Eth(DEFAULT_ETH_NODE)
+    this.provider =
+      opts.provider || new ethers.providers.WebSocketProvider(DEFAULT_ETH_NODE)
     this.network = opts.network || '1'
   }
 
-  // !!! This function can mutate `this.eth`
+  // !!! This function can mutate `this.provider`
   async initRegistry () {
-    if (await this.eth.net.getId() !== '1') {
-      this.eth = new Eth(DEFAULT_ETH_NODE)
+    const network = await this.provider.getNetwork()
+    if (network.chainId !== 1) {
+      this.provider = new ethers.providers.WebSocketProvider(DEFAULT_ETH_NODE)
     }
 
     const address = REGISTRY_MAP[this.network]
@@ -49,7 +32,11 @@ export default class MethodRegistry {
       throw new Error('No method registry found on the requested network.')
     }
 
-    this.registry = new this.eth.Contract(REGISTRY_LOOKUP_ABI, address)
+    this.registry = new ethers.Contract(
+      address,
+      REGISTRY_LOOKUP_ABI,
+      this.provider
+    )
   }
 
   async lookup (sigBytes) {
@@ -57,20 +44,22 @@ export default class MethodRegistry {
       await this.initRegistry()
     }
 
-    return this.registry.methods.entries(sigBytes).call()
+    return this.registry.entries(sigBytes)
   }
 
   parse (signature) {
-    // TODO: Throw if there are unknown types in the signature or there if is any chars after the closing parenthesis
-    let name = signature.match(/^.+(?=\()/)[0]
-    name = name.charAt(0).toUpperCase() + name.slice(1)
-      .split(/(?=[A-Z])/).join(' ')
-
-    const args = signature.match(/\(.+\)/)[0].slice(1, -1).split(',')
+    const fragment = ethers.utils.FunctionFragment.from(signature)
 
     return {
-      name,
-      args: args.map((arg) => { return { type: arg } })
+      name:
+        fragment.name.charAt(0).toUpperCase() +
+        fragment.name
+          .slice(1)
+          .split(/(?=[A-Z])/)
+          .join(' '),
+      args: fragment.inputs.map((input) => {
+        return { type: input.type }
+      })
     }
   }
 }

--- a/src/helpers/lib/token.js
+++ b/src/helpers/lib/token.js
@@ -1,51 +1,10 @@
 export const ETH = '0x0000000000000000000000000000000000000000'
 
-/* eslint-disable key-spacing, quotes */
 export const ERC20_SYMBOL_BYTES32_ABI = [
-  {
-    "constant":true,
-    "inputs":[],
-    "name":"symbol",
-    "outputs":[
-      {
-        "name":"",
-        "type":"bytes32"
-      }
-    ],
-    "payable":false,
-    "stateMutability":"view",
-    "type":"function"
-  }
+  'function symbol() public view returns (bytes32)'
 ]
 
 export const ERC20_SYMBOL_DECIMALS_ABI = [
-  {
-    "constant":true,
-    "inputs":[],
-    "name":"decimals",
-    "outputs":[
-      {
-        "name":"",
-        "type":"uint8"
-      }
-    ],
-    "payable":false,
-    "stateMutability":"view",
-    "type":"function"
-  },
-  {
-    "constant":true,
-    "inputs":[],
-    "name":"symbol",
-    "outputs":[
-      {
-        "name":"",
-        "type":"string"
-      }
-    ],
-    "payable":false,
-    "stateMutability":"view",
-    "type":"function"
-  }
+  'function decimals() public view returns (uint8)',
+  'function symbol() public view returns (string)'
 ]
-/* eslint-enable key-spacing, quotes */

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -1,11 +1,11 @@
 import test from 'ava'
-import BN from 'bn.js'
+import { BigNumber, ethers } from 'ethers'
+
 import { evaluateRaw } from '../../src/lib'
 import { defaultHelpers } from '../../src/helpers'
 import { tenPow } from '../../src/helpers/lib/formatBN'
 import { ETH } from '../../src/helpers/lib/token'
 import knownFunctions from '../../src/data/knownFunctions'
-import { keccak256 } from 'web3-utils'
 
 const int = (value) => ({
   type: 'int256',
@@ -38,388 +38,762 @@ const bytes = (value) => ({
 })
 
 const comparisonCases = [
-  [{
-    source: '`a > 2`',
-    bindings: { a: int(3) }
-  }, 'true'],
-  [{
-    source: '`a > b`',
-    bindings: { a: int(2), b: int(3) }
-  }, 'false'],
-  [{
-    source: '`a >= b`',
-    bindings: { a: int(3), b: int(2) }
-  }, 'true'],
-  [{
-    source: '`a >= b`',
-    bindings: { a: int(1), b: int(2) }
-  }, 'false'],
-  [{
-    source: '`a >= b`',
-    bindings: { a: int(2), b: int(2) }
-  }, 'true'],
-  [{
-    source: '`a < b`',
-    bindings: { a: int(3), b: int(2) }
-  }, 'false'],
-  [{
-    source: '`a < b`',
-    bindings: { a: int(2), b: int(3) }
-  }, 'true'],
-  [{
-    source: '`a <= b`',
-    bindings: { a: int(3), b: int(2) }
-  }, 'false'],
-  [{
-    source: '`a <= b`',
-    bindings: { a: int(1), b: int(2) }
-  }, 'true'],
-  [{
-    source: '`a <= b`',
-    bindings: { a: int(3), b: int(3) }
-  }, 'true'],
-  [{
-    source: '`a == b`',
-    bindings: { a: int(3), b: int(3) }
-  }, 'true'],
-  [{
-    source: '`a != b`',
-    bindings: { a: int(3), b: int(3) }
-  }, 'false'],
-  [{
-    source: '`a > 0x01`',
-    bindings: { a: address('0x0000000000000000000000000000000000000002') }
-  }, 'true'],
-  [{
-    source: '`a != 0x01`',
-    bindings: { a: address('0x0000000000000000000000000000000000000002') }
-  }, 'true'],
-  [{
-    source: '`a != 0x01`',
-    bindings: { a: address('0x0000000000000000000000000000000000000002') }
-  }, 'true'],
-  [{
-    source: '`a > 0x01`',
-    bindings: { a: bytes32('0x0000000000000000000000000000000000000000000000000000000000000002') }
-  }, 'true']
+  [
+    {
+      source: '`a > 2`',
+      bindings: { a: int(3) }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a > b`',
+      bindings: { a: int(2), b: int(3) }
+    },
+    'false'
+  ],
+  [
+    {
+      source: '`a >= b`',
+      bindings: { a: int(3), b: int(2) }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a >= b`',
+      bindings: { a: int(1), b: int(2) }
+    },
+    'false'
+  ],
+  [
+    {
+      source: '`a >= b`',
+      bindings: { a: int(2), b: int(2) }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a < b`',
+      bindings: { a: int(3), b: int(2) }
+    },
+    'false'
+  ],
+  [
+    {
+      source: '`a < b`',
+      bindings: { a: int(2), b: int(3) }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a <= b`',
+      bindings: { a: int(3), b: int(2) }
+    },
+    'false'
+  ],
+  [
+    {
+      source: '`a <= b`',
+      bindings: { a: int(1), b: int(2) }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a <= b`',
+      bindings: { a: int(3), b: int(3) }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a == b`',
+      bindings: { a: int(3), b: int(3) }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a != b`',
+      bindings: { a: int(3), b: int(3) }
+    },
+    'false'
+  ],
+  [
+    {
+      source: '`a > 0x01`',
+      bindings: { a: address('0x0000000000000000000000000000000000000002') }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a != 0x01`',
+      bindings: { a: address('0x0000000000000000000000000000000000000002') }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a != 0x01`',
+      bindings: { a: address('0x0000000000000000000000000000000000000002') }
+    },
+    'true'
+  ],
+  [
+    {
+      source: '`a > 0x01`',
+      bindings: {
+        a: bytes32(
+          '0x0000000000000000000000000000000000000000000000000000000000000002'
+        )
+      }
+    },
+    'true'
+  ]
 ]
 
 const helperCases = [
-  [{
-    source: "helper `@echo(@echo('hi '), 1 + 100000 ^ 0)`",
-    bindings: {}
-  }, 'helper hi hi '],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance, false, 5)` ANT',
-    bindings: { token: address('0x960b236A07cf122663c4303350609A66A7B288C0'), balance: int('647413054590000000000000') }
-  }, 'Balance: 647413.05459 ANT'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance, false, 5)` ANT (non-checksummed)',
-    bindings: { token: address('0x960b236a07cf122663c4303350609a66a7b288c0'), balance: int('647413054590000000000000') }
-  }, 'Balance: 647413.05459 ANT (non-checksummed)'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance, false, 7)` ANT (trailing zeros)',
-    bindings: { token: address('0x960b236A07cf122663c4303350609A66A7B288C0'), balance: int('647413054590000000000000') }
-  }, 'Balance: 647413.0545900 ANT (trailing zeros)'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance, false, 5)` ANT (non-precise)',
-    bindings: { token: address('0x960b236A07cf122663c4303350609A66A7B288C0'), balance: int('647413054595780000000000') }
-  }, 'Balance: ~647413.05459 ANT (non-precise)'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance)`',
-    bindings: { token: address(ETH), balance: int('647413054595780000000000') }
-  }, 'Balance: 647413.05459578 ETH'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance)`',
-    bindings: { token: address('0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7'), balance: int('10') }
-  }, 'Balance: 10 🦄'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance)`',
-    bindings: { token: address('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'), balance: int('10000000000000000000') }
-  }, 'Balance: 10 DAI'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance)`',
-    bindings: { token: address('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'), balance: int('1000000000000000') }
-  }, 'Balance: 0.001 DAI'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance)`',
-    bindings: { token: address('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'), balance: int('1') }
-  }, 'Balance: 0.000000000000000001 DAI'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance, true, 3)`',
-    bindings: { token: address('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'), balance: int('1') }
-  }, 'Balance: ~0.000 DAI'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance, true, 3)`',
-    bindings: { token: address('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'), balance: int('1000000000000000001') }
-  }, 'Balance: ~1.000 DAI'],
-  [{
-    source: 'Balance: `@tokenAmount(token, balance)`',
-    bindings: { token: address('0x89d24a6b4ccb1b6faa2625fe562bdd9a23260359'), balance: int('1000000000000000001') }
-  }, 'Balance: 1.000000000000000001 DAI'],
-  [{
-    source: 'Balance: `@tokenAmount(self.token(): address, balance)`',
-    bindings: { balance: int('10000000000000000000') },
-    options: { to: '0xD39902f046B5885D70e9E66594b65f84D4d1c952' }
-  }, 'Balance: 10 ANT'],
-  [{
-    source: 'Ethereum launched `@formatDate(date)`',
-    bindings: { date: int('1438269793') }
-  }, 'Ethereum launched Jul. 30th 2015'],
-  [{
-    source: "Ethereum launched on a `@formatDate(date, 'EEEE')` in `@formatDate(date, 'MMMM yyyy')`",
-    bindings: { date: int('1438269793') }
-  }, 'Ethereum launched on a Thursday in July 2015'],
-  [{
-    source: "Period duration is `@transformTime(time, 'day')`",
-    bindings: { time: int(3600 * 24 * 2 + 50) }
-  }, 'Period duration is 2 days'],
-  [{
-    source: "Period duration is `@transformTime(time, 'best')`",
-    bindings: { time: int(3600 * 24 * 30) }
-  }, 'Period duration is 1 month'],
-  [{
-    source: '3600 seconds is `@transformTime(3600)`',
-    bindings: {}
-  }, '3600 seconds is 1 hour'],
-  [{
-    source: "10k minutes is `@transformTime(10 ^ 4, 'second', 'minute')`",
-    bindings: {}
-  }, '10k minutes is 600000 seconds'],
-  [{
-    source: 'Hello `@fromHex(firstName)` `@fromHex(lastName, "utf8")`, `@fromHex(n, "number")` `@fromHex("0x69", "ascii")`s the definitive response.',
-    bindings: { firstName: bytes32('0x446f75676c6173'), lastName: bytes32('0x4164616d73'), n: bytes('0x2a') }
-  }, 'Hello Douglas Adams, 42 is the definitive response.'],
-  [{
-    source: 'Change required support to `@formatPct(support)`%',
-    bindings: { support: int((new BN(50)).mul(tenPow(16))) } // 50 * 10^16
-  }, 'Change required support to 50%'],
-  [{
-    source: 'Change required support to `@formatPct(support, 10 ^ 18, 1)`%',
-    bindings: { support: int((new BN(40)).mul(tenPow(16)).add((new BN(43)).mul(tenPow(14)))) } // 40 * 10^16 + 43 * 10^14
-  }, 'Change required support to ~40.4%'],
-  [{
-    source: 'The genesis block is #`@getBlock(n)`',
-    bindings: { n: int(0) },
-    options: { userHelpers: { getBlock: (eth) => async (n) => ({ type: 'string', value: (await eth.getBlock(n)).number }) } }
-  }, 'The genesis block is #0'],
-  [{
-    source: 'Bar `@bar(shift)` foo `@foo(n)`',
-    bindings: { shift: bool(true), n: int(7) },
-    options: { userHelpers: { bar: () => shift => ({ type: 'string', value: shift ? 'BAR' : 'bar' }), foo: () => n => ({ type: 'number', value: n * 7 }) } }
-  }, 'Bar BAR foo 49']
+  [
+    {
+      source: "helper `@echo(@echo('hi '), 1 + 100000 ^ 0)`",
+      bindings: {}
+    },
+    'helper hi hi '
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance, false, 5)` ANT',
+      bindings: {
+        token: address('0x960b236A07cf122663c4303350609A66A7B288C0'),
+        balance: int('647413054590000000000000')
+      }
+    },
+    'Balance: 647413.05459 ANT'
+  ],
+  [
+    {
+      source:
+        'Balance: `@tokenAmount(token, balance, false, 5)` ANT (non-checksummed)',
+      bindings: {
+        token: address('0x960b236a07cf122663c4303350609a66a7b288c0'),
+        balance: int('647413054590000000000000')
+      }
+    },
+    'Balance: 647413.05459 ANT (non-checksummed)'
+  ],
+  [
+    {
+      source:
+        'Balance: `@tokenAmount(token, balance, false, 7)` ANT (trailing zeros)',
+      bindings: {
+        token: address('0x960b236A07cf122663c4303350609A66A7B288C0'),
+        balance: int('647413054590000000000000')
+      }
+    },
+    'Balance: 647413.0545900 ANT (trailing zeros)'
+  ],
+  [
+    {
+      source:
+        'Balance: `@tokenAmount(token, balance, false, 5)` ANT (non-precise)',
+      bindings: {
+        token: address('0x960b236A07cf122663c4303350609A66A7B288C0'),
+        balance: int('647413054595780000000000')
+      }
+    },
+    'Balance: ~647413.05459 ANT (non-precise)'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance)`',
+      bindings: {
+        token: address(ETH),
+        balance: int('647413054595780000000000')
+      }
+    },
+    'Balance: 647413.05459578 ETH'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance)`',
+      bindings: {
+        token: address('0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7'),
+        balance: int('10')
+      }
+    },
+    'Balance: 10 🦄'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance)`',
+      bindings: {
+        token: address('0x6b175474e89094c44da98b954eedeac495271d0f'),
+        balance: int('10000000000000000000')
+      }
+    },
+    'Balance: 10 DAI'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance)`',
+      bindings: {
+        token: address('0x6b175474e89094c44da98b954eedeac495271d0f'),
+        balance: int('1000000000000000')
+      }
+    },
+    'Balance: 0.001 DAI'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance)`',
+      bindings: {
+        token: address('0x6b175474e89094c44da98b954eedeac495271d0f'),
+        balance: int('1')
+      }
+    },
+    'Balance: 0.000000000000000001 DAI'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance, true, 3)`',
+      bindings: {
+        token: address('0x6b175474e89094c44da98b954eedeac495271d0f'),
+        balance: int('1')
+      }
+    },
+    'Balance: ~0.000 DAI'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance, true, 3)`',
+      bindings: {
+        token: address('0x6b175474e89094c44da98b954eedeac495271d0f'),
+        balance: int('1000000000000000001')
+      }
+    },
+    'Balance: ~1.000 DAI'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(token, balance)`',
+      bindings: {
+        token: address('0x6b175474e89094c44da98b954eedeac495271d0f'),
+        balance: int('1000000000000000001')
+      }
+    },
+    'Balance: 1.000000000000000001 DAI'
+  ],
+  [
+    {
+      source: 'Balance: `@tokenAmount(self.token(): address, balance)`',
+      bindings: { balance: int('10000000000000000000') },
+      options: { to: '0xD39902f046B5885D70e9E66594b65f84D4d1c952' }
+    },
+    'Balance: 10 ANT'
+  ],
+  [
+    {
+      source: 'Ethereum launched `@formatDate(date)`',
+      bindings: { date: int('1438269793') }
+    },
+    'Ethereum launched Jul. 30th 2015'
+  ],
+  [
+    {
+      source:
+        "Ethereum launched on a `@formatDate(date, 'EEEE')` in `@formatDate(date, 'MMMM yyyy')`",
+      bindings: { date: int('1438269793') }
+    },
+    'Ethereum launched on a Thursday in July 2015'
+  ],
+  [
+    {
+      source: "Period duration is `@transformTime(time, 'day')`",
+      bindings: { time: int(3600 * 24 * 2 + 50) }
+    },
+    'Period duration is 2 days'
+  ],
+  [
+    {
+      source: "Period duration is `@transformTime(time, 'best')`",
+      bindings: { time: int(3600 * 24 * 30) }
+    },
+    'Period duration is 1 month'
+  ],
+  [
+    {
+      source: '3600 seconds is `@transformTime(3600)`',
+      bindings: {}
+    },
+    '3600 seconds is 1 hour'
+  ],
+  [
+    {
+      source: "10k minutes is `@transformTime(10 ^ 4, 'second', 'minute')`",
+      bindings: {}
+    },
+    '10k minutes is 600000 seconds'
+  ],
+  [
+    {
+      source:
+        'Hello `@fromHex(firstName)` `@fromHex(lastName, "utf8")`, `@fromHex(n, "number")` is the definitive response.',
+      bindings: {
+        firstName: bytes32('0x446f75676c6173'),
+        lastName: bytes32('0x4164616d73'),
+        n: bytes('0x2a')
+      }
+    },
+    'Hello Douglas Adams, 42 is the definitive response.'
+  ],
+  [
+    {
+      source: 'Change required support to `@formatPct(support)`%',
+      bindings: { support: int(BigNumber.from(50).mul(tenPow(16))) } // 50 * 10^16
+    },
+    'Change required support to 50%'
+  ],
+  [
+    {
+      source: 'Change required support to `@formatPct(support, 10 ^ 18, 1)`%',
+      bindings: {
+        support: int(
+          BigNumber.from(40)
+            .mul(tenPow(16))
+            .add(BigNumber.from(43).mul(tenPow(14)))
+        )
+      } // 40 * 10^16 + 43 * 10^14
+    },
+    'Change required support to ~40.4%'
+  ],
+  [
+    {
+      source: 'The genesis block is #`@getBlock(n)`',
+      bindings: { n: int(0) },
+      options: {
+        userHelpers: {
+          getBlock: (provider) => async (n) => ({
+            type: 'string',
+            value: (await provider.getBlock(n.toNumber())).number
+          })
+        }
+      }
+    },
+    'The genesis block is #0'
+  ],
+  [
+    {
+      source: 'Bar `@bar(shift)` foo `@foo(n)`',
+      bindings: { shift: bool(true), n: int(7) },
+      options: {
+        userHelpers: {
+          bar: () => (shift) => ({
+            type: 'string',
+            value: shift ? 'BAR' : 'bar'
+          }),
+          foo: () => (n) => ({ type: 'number', value: n * 7 })
+        }
+      }
+    },
+    'Bar BAR foo 49'
+  ]
 ]
 
 const dataDecodeCases = [
-  [{
-    source: 'Perform action: `@radspec(addr, data)`',
-    bindings: {
-      addr: address(),
-      data: bytes('0x13af40350000000000000000000000000000000000000000000000000000000000000002') // setOwner(address), on knownFunctions
-    }
-  }, 'Perform action: Set 0x0000000000000000000000000000000000000002 as the new owner'],
-  [{
-    source: 'Payroll: `@radspec(addr, data)`!',
-    bindings: {
-      addr: address(),
-      data: bytes('0x6881385b') // payday(), on knownFunctions
-    }
-  }, 'Payroll: Get owed Payroll allowance!'],
-  [{
-    source: 'Decentraland: `@radspec(addr, data)`',
-    bindings: {
-      addr: address(),
-      data: bytes('0x19dad16d00000000000000000000000000000000000000000000000000000000000061A8') // setOwnerCutPerMillion(uint256), on decentraland's knownFunctions
-    }
-  }, 'Decentraland: Set fees to 2.5%'],
-  [{
-    source: 'Decentraland: `@radspec(addr, data)`',
-    bindings: {
-      addr: address(),
-      data: bytes('0x1206dc5f00000000000000000000000031ab1f92344e3277ce9404e4e097dab7514e6d27') // transferMarketplaceOwnership(address), on decentraland's knownFunctions
-    }
-  }, 'Decentraland: Transfer ownership of the marketplace to 0x31AB1f92344e3277ce9404E4e097dab7514E6D27'],
-  [{
-    source: 'Transfer: `@radspec(addr, data)`',
-    bindings: {
-      addr: address('0x960b236a07cf122663c4303350609a66a7b288c0'),
-      data: bytes('0xa9059cbb00000000000000000000000031ab1f92344e3277ce9404e4e097dab7514e6d2700000000000000000000000000000000000000000000000821ab0d4414980000') // transfer(), on knownFunctions requiring helpers
-    }
-  }, 'Transfer: Transfer 150 ANT to 0x31AB1f92344e3277ce9404E4e097dab7514E6D27'],
-  [{
-    source: 'Cast a `@radspec(addr, data)`',
-    bindings: {
-      addr: address(),
-      data: bytes('0xdf133bca') // vote(uint256,bool,bool), from on-chain registry
-    }
-  }, 'Cast a Vote'],
-  [{
-    source: 'Perform action: `@radspec(addr, data)`',
-    bindings: {
-      addr: address(),
-      data: bytes('0x12345678') // random signature
-    }
-  }, 'Perform action: Unknown function (0x12345678)'],
-  [{
-    source: 'Perform action: `@radspec(addr, data)`',
-    bindings: {
-      addr: address(),
-      data: bytes('0x12') // bad signature
-    }
-  }, 'Perform action: Unknown function (0x12)']
+  [
+    {
+      source: 'Perform action: `@radspec(addr, data)`',
+      bindings: {
+        addr: address(),
+        data: bytes(
+          '0x13af40350000000000000000000000000000000000000000000000000000000000000002'
+        ) // setOwner(address), on knownFunctions
+      }
+    },
+    'Perform action: Set 0x0000000000000000000000000000000000000002 as the new owner'
+  ],
+  [
+    {
+      source: 'Payroll: `@radspec(addr, data)`!',
+      bindings: {
+        addr: address(),
+        data: bytes('0x6881385b') // payday(), on knownFunctions
+      }
+    },
+    'Payroll: Get owed Payroll allowance!'
+  ],
+  [
+    {
+      source: 'Decentraland: `@radspec(addr, data)`',
+      bindings: {
+        addr: address(),
+        data: bytes(
+          '0x19dad16d00000000000000000000000000000000000000000000000000000000000061A8'
+        ) // setOwnerCutPerMillion(uint256), on decentraland's knownFunctions
+      }
+    },
+    'Decentraland: Set fees to 2.5%'
+  ],
+  [
+    {
+      source: 'Decentraland: `@radspec(addr, data)`',
+      bindings: {
+        addr: address(),
+        data: bytes(
+          '0x1206dc5f00000000000000000000000031ab1f92344e3277ce9404e4e097dab7514e6d27'
+        ) // transferMarketplaceOwnership(address), on decentraland's knownFunctions
+      }
+    },
+    'Decentraland: Transfer ownership of the marketplace to 0x31AB1f92344e3277ce9404E4e097dab7514E6D27'
+  ],
+  [
+    {
+      source: 'Transfer: `@radspec(addr, data)`',
+      bindings: {
+        addr: address('0x960b236a07cf122663c4303350609a66a7b288c0'),
+        data: bytes(
+          '0xa9059cbb00000000000000000000000031ab1f92344e3277ce9404e4e097dab7514e6d2700000000000000000000000000000000000000000000000821ab0d4414980000'
+        ) // transfer(), on knownFunctions requiring helpers
+      }
+    },
+    'Transfer: Transfer 150 ANT to 0x31AB1f92344e3277ce9404E4e097dab7514E6D27'
+  ],
+  [
+    {
+      source: 'Cast a `@radspec(addr, data)`',
+      bindings: {
+        addr: address(),
+        data: bytes('0xdf133bca') // vote(uint256,bool,bool), from on-chain registry
+      }
+    },
+    'Cast a Vote'
+  ],
+  [
+    {
+      source: 'Perform action: `@radspec(addr, data)`',
+      bindings: {
+        addr: address(),
+        data: bytes('0x12345678') // random signature
+      }
+    },
+    'Perform action: Unknown function (0x12345678)'
+  ],
+  [
+    {
+      source: 'Perform action: `@radspec(addr, data)`',
+      bindings: {
+        addr: address(),
+        data: bytes('0x12') // bad signature
+      }
+    },
+    'Perform action: Unknown function (0x12)'
+  ]
 ]
 
 const cases = [
   // Bindings
-  [{
-    source: 'a is `a`, b is `b` and "c d" is `c d`',
-    bindings: { a: int(1), b: int(2), c: int(3), d: int(4) }
-  }, 'a is 1, b is 2 and "c d" is 3 4'],
-  [{
-    source: "An empty string`''`",
-    bindings: {}
-  }, 'An empty string'],
+  [
+    {
+      source: 'a is `a`, b is `b` and "c d" is `c d`',
+      bindings: { a: int(1), b: int(2), c: int(3), d: int(4) }
+    },
+    'a is 1, b is 2 and "c d" is 3 4'
+  ],
+  [
+    {
+      source: "An empty string`''`",
+      bindings: {}
+    },
+    'An empty string'
+  ],
 
   // Maths
-  [{
-    source: 'Will multiply `a` by 7 and return `a * 7`',
-    bindings: { a: int(122) }
-  }, 'Will multiply 122 by 7 and return 854'],
-  [{
-    source: 'First case is `2 * 2 + 6`, second case is `2 * (2 + 6)`'
-  }, 'First case is 10, second case is 16'],
-  [{
-    source: 'First case is `2^5`, second case is `2^2 + 1`'
-  }, 'First case is 32, second case is 5'],
-  [{
-    source: 'First case is `(11 - 1) * 2^5`, second case is `3 * 2 ^ (4 - 1) + 1`'
-  }, 'First case is 320, second case is 25'],
-  [{
-    source: 'First case is `(11 - 1) / 2`, second case is `3 * 2 ^ (4 - 1) / 3`'
-  }, 'First case is 5, second case is 8'],
-  [{
-    source: 'First case is `(11 - 1) % 3`, second case is `3 * 2 % 5`'
-  }, 'First case is 1, second case is 1'],
-  [{
-    source: "Basic arithmetic: `a` + `b` is `a + b`, - `c` that's `a + b - c`, quick mafs",
-    bindings: { a: int(2), b: int(2), c: int(1) }
-  }, "Basic arithmetic: 2 + 2 is 4, - 1 that's 3, quick mafs"],
-  [{
-    source: 'This will default to `b`: `a || b`',
-    bindings: { a: int(0), b: int(1) }
-  }, 'This will default to 1: 1'],
-  [{
-    source: 'This will default to `a`: `a || b`',
-    bindings: { a: int(1), b: int(0) }
-  }, 'This will default to 1: 1'],
-  [{
-    source: 'This will default to `b`: `a || b`',
-    bindings: {
-      a: bytes32('0x0000000000000000000000000000000000000000000000000000000000000000'),
-      b: int(1)
-    }
-  }, 'This will default to 1: 1'],
+  [
+    {
+      source: 'Will multiply `a` by 7 and return `a * 7`',
+      bindings: { a: int(122) }
+    },
+    'Will multiply 122 by 7 and return 854'
+  ],
+  [
+    {
+      source: 'First case is `2 * 2 + 6`, second case is `2 * (2 + 6)`'
+    },
+    'First case is 10, second case is 16'
+  ],
+  [
+    {
+      source: 'First case is `2^5`, second case is `2^2 + 1`'
+    },
+    'First case is 32, second case is 5'
+  ],
+  [
+    {
+      source:
+        'First case is `(11 - 1) * 2^5`, second case is `3 * 2 ^ (4 - 1) + 1`'
+    },
+    'First case is 320, second case is 25'
+  ],
+  [
+    {
+      source:
+        'First case is `(11 - 1) / 2`, second case is `3 * 2 ^ (4 - 1) / 3`'
+    },
+    'First case is 5, second case is 8'
+  ],
+  [
+    {
+      source: 'First case is `(11 - 1) % 3`, second case is `3 * 2 % 5`'
+    },
+    'First case is 1, second case is 1'
+  ],
+  [
+    {
+      source:
+        "Basic arithmetic: `a` + `b` is `a + b`, - `c` that's `a + b - c`, quick mafs",
+      bindings: { a: int(2), b: int(2), c: int(1) }
+    },
+    "Basic arithmetic: 2 + 2 is 4, - 1 that's 3, quick mafs"
+  ],
+  [
+    {
+      source: 'This will default to `b`: `a || b`',
+      bindings: { a: int(0), b: int(1) }
+    },
+    'This will default to 1: 1'
+  ],
+  [
+    {
+      source: 'This will default to `a`: `a || b`',
+      bindings: { a: int(1), b: int(0) }
+    },
+    'This will default to 1: 1'
+  ],
+  [
+    {
+      source: 'This will default to `b`: `a || b`',
+      bindings: {
+        a: bytes32(
+          '0x0000000000000000000000000000000000000000000000000000000000000000'
+        ),
+        b: int(1)
+      }
+    },
+    'This will default to 1: 1'
+  ],
 
   // Conditionals
-  [{
-    source: 'True is not `false ? true : false`',
-    bindings: {}
-  }, 'True is not false'],
-  [{
-    source: "`a == 0x0 ? 'concat ' + a : 'else'`",
-    bindings: { a: address('0x0000000000000000000000000000000000000000') }
-  }, 'concat 0x0000000000000000000000000000000000000000'],
-  [{
-    source: "`a == 0x0 ? 'concat ' + a : 'else'`",
-    bindings: { a: address('0x0000000000000000000000000000000000000001') }
-  }, 'else'],
+  [
+    {
+      source: 'True is not `false ? true : false`',
+      bindings: {}
+    },
+    'True is not false'
+  ],
+  [
+    {
+      source: "`a == 0x0 ? 'concat ' + a : 'else'`",
+      bindings: { a: address('0x0000000000000000000000000000000000000000') }
+    },
+    'concat 0x0000000000000000000000000000000000000000'
+  ],
+  [
+    {
+      source: "`a == 0x0 ? 'concat ' + a : 'else'`",
+      bindings: { a: address('0x0000000000000000000000000000000000000001') }
+    },
+    'else'
+  ],
 
   // External calls
-  [{
-    source: 'Allocate `amount token.symbol(): string`.',
-    bindings: { amount: int(100), token: address('0x960b236A07cf122663c4303350609A66A7B288C0') }
-  }, 'Allocate 100 ANT.'],
-  [{
-    source: 'Allocate `amount token.symbol(): string` (non-checksummed).',
-    bindings: { amount: int(100), token: address('0x960b236a07cf122663c4303350609a66a7b288c0') }
-  }, 'Allocate 100 ANT (non-checksummed).'],
-  [{
-    source: 'Burns the `token.symbol(): string` balance of `person` (balance is `token.balanceOf(person): uint256 / 1000000000000000000`)',
-    bindings: { token: address('0x960b236A07cf122663c4303350609A66A7B288C0'), person: address('0x0000000000000000000000000000000000000001') }
-  }, 'Burns the ANT balance of 0x0000000000000000000000000000000000000001 (balance is 0)'],
-  [{
-    source: 'Burns the `self.symbol(): string` balance of `person` (balance is `self.balanceOf(person): uint256 / 1000000000000000000`)',
-    bindings: { person: address('0x0000000000000000000000000000000000000001') },
-    options: { to: '0x960b236A07cf122663c4303350609A66A7B288C0' }
-  }, 'Burns the ANT balance of 0x0000000000000000000000000000000000000001 (balance is 0)'],
-  [{
-    source: 'Send ETH to the sale at block `((self.controller(): address).sale(): address).initialBlock(): uint` from `person`',
-    bindings: { person: address('0x0000000000000000000000000000000000000001') },
-    options: { to: '0x960b236A07cf122663c4303350609A66A7B288C0' }
-  }, 'Send ETH to the sale at block 3723000 from 0x0000000000000000000000000000000000000001'],
-  [{
-    source: "Initialize Finance app for Vault at `_vault` with period length of `(_periodDuration - _periodDuration % 86400) / 86400` day`_periodDuration >= 172800 ? 's' : ' '`",
-    bindings: { _periodDuration: int(86400 * 2), _vault: address('0x960b236A07cf122663c4303350609A66A7B288C0') }
-  }, 'Initialize Finance app for Vault at 0x960b236A07cf122663c4303350609A66A7B288C0 with period length of 2 days'],
-  [{
-    source: "Vote `_supports ? 'yay' : 'nay'`",
-    bindings: { _supports: bool(false) }
-  }, 'Vote nay'],
-  [{
-    source: 'Token `_amount / 10^18`',
-    bindings: { _amount: int(new BN(10).mul(new BN(10).pow(new BN(18)))) }
-  }, 'Token 10'],
-  [{
-    source: "`_bool ? 'h' + _var + 'o' : 'bye'`",
-    bindings: { _bool: bool(true), _var: string('ell') }
-  }, 'hello'],
+  [
+    {
+      source: 'Allocate `amount token.symbol(): string`.',
+      bindings: {
+        amount: int(100),
+        token: address('0x960b236A07cf122663c4303350609A66A7B288C0')
+      }
+    },
+    'Allocate 100 ANT.'
+  ],
+  [
+    {
+      source: 'Allocate `amount token.symbol(): string` (non-checksummed).',
+      bindings: {
+        amount: int(100),
+        token: address('0x960b236a07cf122663c4303350609a66a7b288c0')
+      }
+    },
+    'Allocate 100 ANT (non-checksummed).'
+  ],
+  [
+    {
+      source:
+        'Burns the `token.symbol(): string` balance of `person` (balance is `token.balanceOf(person): uint256 / 1000000000000000000`)',
+      bindings: {
+        token: address('0x960b236A07cf122663c4303350609A66A7B288C0'),
+        person: address('0x0000000000000000000000000000000000000001')
+      }
+    },
+    'Burns the ANT balance of 0x0000000000000000000000000000000000000001 (balance is 0)'
+  ],
+  [
+    {
+      source:
+        'Burns the `self.symbol(): string` balance of `person` (balance is `self.balanceOf(person): uint256 / 1000000000000000000`)',
+      bindings: {
+        person: address('0x0000000000000000000000000000000000000001')
+      },
+      options: { to: '0x960b236A07cf122663c4303350609A66A7B288C0' }
+    },
+    'Burns the ANT balance of 0x0000000000000000000000000000000000000001 (balance is 0)'
+  ],
+  [
+    {
+      source:
+        'Send ETH to the sale at block `((self.controller(): address).sale(): address).initialBlock(): uint` from `person`',
+      bindings: {
+        person: address('0x0000000000000000000000000000000000000001')
+      },
+      options: { to: '0x960b236A07cf122663c4303350609A66A7B288C0' }
+    },
+    'Send ETH to the sale at block 3723000 from 0x0000000000000000000000000000000000000001'
+  ],
+  [
+    {
+      source:
+        "Initialize Finance app for Vault at `_vault` with period length of `(_periodDuration - _periodDuration % 86400) / 86400` day`_periodDuration >= 172800 ? 's' : ' '`",
+      bindings: {
+        _periodDuration: int(86400 * 2),
+        _vault: address('0x960b236A07cf122663c4303350609A66A7B288C0')
+      }
+    },
+    'Initialize Finance app for Vault at 0x960b236A07cf122663c4303350609A66A7B288C0 with period length of 2 days'
+  ],
+  [
+    {
+      source: "Vote `_supports ? 'yay' : 'nay'`",
+      bindings: { _supports: bool(false) }
+    },
+    'Vote nay'
+  ],
+  [
+    {
+      source: 'Token `_amount / 10^18`',
+      bindings: {
+        _amount: int(
+          BigNumber.from(10).mul(BigNumber.from(10).pow(BigNumber.from(18)))
+        )
+      }
+    },
+    'Token 10'
+  ],
+  [
+    {
+      source: "`_bool ? 'h' + _var + 'o' : 'bye'`",
+      bindings: { _bool: bool(true), _var: string('ell') }
+    },
+    'hello'
+  ],
 
   // External calls with multiple return values
-  [{
-    source: "Explicit: Transaction with ID `txId` was sent to `self.getTransaction(txId): (uint64, uint256, uint256, uint64, address, <address>, bool, uint64)`",
-    bindings: { txId: { type: 'uint256', value: 1 } },
-    options: { to: '0xf562B25Db6e707694ceC3A4908dC58fF6bDABa40' },
-  }, 'Explicit: Transaction with ID 1 was sent to 0x52EC80600642CeddE9De1F570335481C348BE74C'],
-  [{
-    source: "Implicit: `token.symbol(): (string)`",
-    bindings: { token: address('0x960b236a07cf122663c4303350609a66a7b288c0') }
-  }, 'Implicit: ANT'],
-  [{
-    source: "Explicit (last type): `self.getTransaction(txId): (uint64, uint256, uint256, uint64, address, address, bool, <uint64>)`",
-    bindings: { txId: { type: 'uint256', value: 1 } },
-    options: { to: '0xf562B25Db6e707694ceC3A4908dC58fF6bDABa40' },
-  }, 'Explicit (last type): 1568811601'],
-  [{
-    source: "Explicit (first type): `self.getTransaction(txId): (<uint64>, uint256, uint256, uint64, address, address, bool, uint64)`",
-    bindings: { txId: { type: 'uint256', value: 1 } },
-    options: { to: '0xf562B25Db6e707694ceC3A4908dC58fF6bDABa40' },
-  }, 'Explicit (first type): 0'],
+  [
+    {
+      source:
+        'Explicit: Transaction with ID `txId` was sent to `self.getTransaction(txId): (uint64, uint256, uint256, uint64, address, <address>, bool, uint64)`',
+      bindings: { txId: { type: 'uint256', value: 1 } },
+      options: { to: '0xf562B25Db6e707694ceC3A4908dC58fF6bDABa40' }
+    },
+    'Explicit: Transaction with ID 1 was sent to 0x52EC80600642CeddE9De1F570335481C348BE74C'
+  ],
+  [
+    {
+      source: 'Implicit: `token.symbol(): (string)`',
+      bindings: {
+        token: address('0x960b236a07cf122663c4303350609a66a7b288c0')
+      }
+    },
+    'Implicit: ANT'
+  ],
+  [
+    {
+      source:
+        'Explicit (last type): `self.getTransaction(txId): (uint64, uint256, uint256, uint64, address, address, bool, <uint64>)`',
+      bindings: { txId: { type: 'uint256', value: 1 } },
+      options: { to: '0xf562B25Db6e707694ceC3A4908dC58fF6bDABa40' }
+    },
+    'Explicit (last type): 1568811601'
+  ],
+  [
+    {
+      source:
+        'Explicit (first type): `self.getTransaction(txId): (<uint64>, uint256, uint256, uint64, address, address, bool, uint64)`',
+      bindings: { txId: { type: 'uint256', value: 1 } },
+      options: { to: '0xf562B25Db6e707694ceC3A4908dC58fF6bDABa40' }
+    },
+    'Explicit (first type): 0'
+  ],
 
   // msg.(sender | value | data) options
-  [{
-    source: "No value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `receiver`",
-    bindings: { token: address(ETH), receiver:  address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb') },
-    options: { from: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7'},
-  }, 'No value: Send 0 ETH from 0xb4124cEB3451635DAcedd11767f004d8a28c6eE7 to 0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb'],
+  [
+    {
+      source:
+        'No value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `receiver`',
+      bindings: {
+        token: address(ETH),
+        receiver: address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb')
+      },
+      options: { from: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7' }
+    },
+    'No value: Send 0 ETH from 0xb4124cEB3451635DAcedd11767f004d8a28c6eE7 to 0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb'
+  ],
 
-  [{
-    source: "With value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `receiver`",
-    bindings: { token: address(ETH), receiver:  address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb') },
-    options: { from: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7', value: '1000000000000000000' },
-  }, 'With value: Send 1 ETH from 0xb4124cEB3451635DAcedd11767f004d8a28c6eE7 to 0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb'],
+  [
+    {
+      source:
+        'With value: Send `@tokenAmount(token, msg.value)` from `msg.sender` to `receiver`',
+      bindings: {
+        token: address(ETH),
+        receiver: address('0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb')
+      },
+      options: {
+        from: '0xb4124cEB3451635DAcedd11767f004d8a28c6eE7',
+        value: '1000000000000000000'
+      }
+    },
+    'With value: Send 1 ETH from 0xb4124cEB3451635DAcedd11767f004d8a28c6eE7 to 0x8401Eb5ff34cc943f096A32EF3d5113FEbE8D4Eb'
+  ],
 
-  [{
-    source: "Sending tx with data `msg.data` to contract at `contract`",
-    bindings: { contract: address('0x960b236A07cf122663c4303350609A66A7B288C0') },
-    options: { data: '0xabcdef'}
-  }, "Sending tx with data 0xabcdef to contract at 0x960b236A07cf122663c4303350609A66A7B288C0"],
-  
+  [
+    {
+      source: 'Sending tx with data `msg.data` to contract at `contract`',
+      bindings: {
+        contract: address('0x960b236A07cf122663c4303350609A66A7B288C0')
+      },
+      options: { data: '0xabcdef' }
+    },
+    'Sending tx with data 0xabcdef to contract at 0x960b236A07cf122663c4303350609A66A7B288C0'
+  ],
+
   // using msg.data on a helper
-  [{
-    source: "Performs a call to `@radspec(contract, msg.data)`",
-    bindings: { contract: address('0x960b236A07cf122663c4303350609A66A7B288C0') },
-    options: { data: keccak256(Object.keys(knownFunctions)[3]).slice(0,10) }
-  }, `Performs a call to ${Object.values(knownFunctions)[3]}`],
+  [
+    {
+      source: 'Performs a call to `@radspec(contract, msg.data)`',
+      bindings: {
+        contract: address('0x960b236A07cf122663c4303350609A66A7B288C0')
+      },
+      options: {
+        data: ethers.utils
+          .keccak256(ethers.utils.toUtf8Bytes(Object.keys(knownFunctions)[3]))
+          .slice(0, 10)
+      }
+    },
+    `Performs a call to ${Object.values(knownFunctions)[3]}`
+  ],
 
   ...comparisonCases,
   ...helperCases,
@@ -429,14 +803,10 @@ const cases = [
 cases.forEach(([input, expected], index) => {
   test(`${index} - ${input.source}`, async (t) => {
     const { userHelpers } = input.options || {}
-    const actual = await evaluateRaw(
-      input.source,
-      input.bindings,
-      {
-        ...input.options,
-        availableHelpers: { ...defaultHelpers, ...userHelpers }
-      }
-    )
+    const actual = await evaluateRaw(input.source, input.bindings, {
+      ...input.options,
+      availableHelpers: { ...defaultHelpers, ...userHelpers }
+    })
     t.is(
       actual,
       expected,

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import test from 'ava'
 import { evaluate } from '../src'
 
-test('radspec#evaluate', async (t) => {
+test('radspec#evaluate json abi', async (t) => {
   const expression = 'Will multiply `a` by 7 and return `a * 7`.'
   const call = {
     abi: [{
@@ -17,6 +17,19 @@ test('radspec#evaluate', async (t) => {
         type: 'uint256'
       }]
     }],
+    transaction: {
+      to: '0x8521742d3f456BD237E312d6E30724960f72517A',
+      data: '0xc6888fa1000000000000000000000000000000000000000000000000000000000000007a'
+    }
+  }
+
+  t.is(await evaluate(expression, call), 'Will multiply 122 by 7 and return 854.')
+})
+
+test('radspec#evaluate Human-Readable abi', async (t) => {
+  const expression = 'Will multiply `a` by 7 and return `a * 7`.'
+  const call = {
+    abi: ['function multiply(uint256 a) public view returns(uint256)'],
     transaction: {
       to: '0x8521742d3f456BD237E312d6E30724960f72517A',
       data: '0xc6888fa1000000000000000000000000000000000000000000000000000000000000007a'


### PR DESCRIPTION
This PR refactor radspec logic to use `ethers.js` library instead of several packages of `web3` and `bn.js`.

The changes are structure in three commits: 
1. Update dependencies and documentation.
2. Refactor the logic under `src`.
3. Update tests

Note we are using the latest ethers beta version, the documentation site might be helpful to better understand part of the logic. In specific how the Provider, Interface, and Fragments objects work:
- [Provider](https://docs-beta.ethers.io/api/providers/provider/)
- [Interface](https://docs-beta.ethers.io/api/utils/abi/interface/)
- [Fragments](https://docs-beta.ethers.io/api/utils/abi/fragments/#fragments)
