### PR TITLE
Update: packages and documentation

### DIFF
--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -52,6 +52,7 @@ class TypedValue {
  * @param {radspec/Bindings} bindings An object of bindings and their values
  * @param {?Object} options An options object
  * @param {?Object} options.availablehelpers Available helpers
+ * @param {?Object} options.availableFunctions Available function signatures
  * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
  * @param {?string} options.to The destination address for this expression's transaction
  * @property {radspec/parser/AST} ast
@@ -61,7 +62,7 @@ export class Evaluator {
   constructor (
     ast,
     bindings,
-    { availableHelpers = {}, provider, from, to, value = '0', data } = {}
+    { availableHelpers = {}, availableFunctions = {}, provider, from, to, value = '0', data } = {}
   ) {
     this.ast = ast
     this.bindings = bindings
@@ -72,6 +73,7 @@ export class Evaluator {
     this.value = new TypedValue('uint', BigNumber.from(value))
     this.data = data && new TypedValue('bytes', data)
     this.helpers = new HelperManager(availableHelpers)
+    this.functions = availableFunctions
   }
 
   /**
@@ -298,7 +300,8 @@ export class Evaluator {
       const inputs = await this.evaluateNodes(node.inputs)
       const result = await this.helpers.execute(helperName, inputs, {
         provider: this.provider,
-        evaluator: this
+        evaluator: this,
+        functions: this.functions
       })
 
       return new TypedValue(result.type, result.value)
@@ -368,6 +371,7 @@ export class Evaluator {
  * @param {radspec/Bindings} bindings An object of bindings and their values
  * @param {?Object} options An options object
  * @param {?Object} options.availablehelpers Available helpers
+ * @param {?Object} options.availableFunctions Available function signatures
  * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
  * @param {?string} options.to The destination address for this expression's transaction
  * @return {string}

--- a/src/evaluator/index.js
+++ b/src/evaluator/index.js
@@ -2,7 +2,7 @@
  * @module radspec/evaluator
  */
 
-import { ethers, BigNumber } from 'ethers'
+import { BigNumber, providers as ethersProvider, utils as ethersUtils } from 'ethers'
 
 import types from '../types'
 import HelperManager from '../helpers/HelperManager'
@@ -27,10 +27,10 @@ class TypedValue {
     }
 
     if (this.type === 'address') {
-      if (!ethers.utils.isAddress(this.value)) {
+      if (!ethersUtils.isAddress(this.value)) {
         throw new Error(`Invalid address "${this.value}"`)
       }
-      this.value = ethers.utils.getAddress(this.value)
+      this.value = ethersUtils.getAddress(this.value)
     }
   }
 
@@ -53,7 +53,7 @@ class TypedValue {
  * @param {?Object} options An options object
  * @param {?Object} options.availablehelpers Available helpers
  * @param {?Object} options.availableFunctions Available function signatures
- * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
+ * @param {?ethersProvider.Provider} options.provider EIP 1193 provider
  * @param {?string} options.to The destination address for this expression's transaction
  * @property {radspec/parser/AST} ast
  * @property {radspec/Bindings} bindings
@@ -67,7 +67,7 @@ export class Evaluator {
     this.ast = ast
     this.bindings = bindings
     this.provider =
-      provider || new ethers.providers.WebSocketProvider(DEFAULT_ETH_NODE)
+      provider || new ethersProvider.WebSocketProvider(DEFAULT_ETH_NODE)
     this.from = from && new TypedValue('address', from)
     this.to = to && new TypedValue('address', to)
     this.value = new TypedValue('uint', BigNumber.from(value))
@@ -244,7 +244,7 @@ export class Evaluator {
 
       if (target.type !== 'bytes20' && target.type !== 'address') {
         this.panic('Target of call expression was not an address')
-      } else if (!ethers.utils.isAddress(target.value)) {
+      } else if (!ethersUtils.isAddress(target.value)) {
         this.panic(`Invalid address "${this.value}"`)
       }
 
@@ -273,7 +273,7 @@ export class Evaluator {
           stateMutability: 'view'
         }
       ]
-      const ethersInterface = new ethers.utils.Interface(abi)
+      const ethersInterface = new ethersUtils.Interface(abi)
 
       const txData = ethersInterface.encodeFunctionData(
         node.callee,
@@ -372,7 +372,7 @@ export class Evaluator {
  * @param {?Object} options An options object
  * @param {?Object} options.availablehelpers Available helpers
  * @param {?Object} options.availableFunctions Available function signatures
- * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
+ * @param {?ethersProvider.Provider} options.provider EIP 1193 provider
  * @param {?string} options.to The destination address for this expression's transaction
  * @return {string}
  */

--- a/src/helpers/HelperManager.js
+++ b/src/helpers/HelperManager.js
@@ -29,7 +29,7 @@ export default class HelperManager {
    * @param  {string} helper Helper name
    * @param  {Array<radspec/evaluator/TypedValue>} inputs
    * @param  {Object} config Configuration for running helper
-   * @param  {ethers.providers.Provider} config.provider Current provider
+   * @param  {ethersProvider.Provider} config.provider Current provider
    * @param  {radspec/evaluator/Evaluator} config.evaluator Current evaluator
    * @param  {Object} config.functions Current function signatures
    * @return {Promise<radspec/evaluator/TypedValue>}

--- a/src/helpers/HelperManager.js
+++ b/src/helpers/HelperManager.js
@@ -29,13 +29,14 @@ export default class HelperManager {
    * @param  {string} helper Helper name
    * @param  {Array<radspec/evaluator/TypedValue>} inputs
    * @param  {Object} config Configuration for running helper
-   * @param {ethers.providers.Provider} config.provider Current provider
+   * @param  {ethers.providers.Provider} config.provider Current provider
    * @param  {radspec/evaluator/Evaluator} config.evaluator Current evaluator
+   * @param  {Object} config.functions Current function signatures
    * @return {Promise<radspec/evaluator/TypedValue>}
    */
-  execute (helper, inputs, { provider, evaluator }) {
+  execute (helper, inputs, { provider, evaluator, functions }) {
     inputs = inputs.map((input) => input.value) // pass values directly
-    return this.availableHelpers[helper](provider, evaluator)(...inputs)
+    return this.availableHelpers[helper](provider, evaluator, functions)(...inputs)
   }
 
   /**

--- a/src/helpers/fromHex.js
+++ b/src/helpers/fromHex.js
@@ -1,4 +1,4 @@
-import { ethers, BigNumber } from 'ethers'
+import { BigNumber, utils as ethersUtils } from 'ethers'
 
 export default () =>
   /**
@@ -13,5 +13,5 @@ export default () =>
     value:
       to === 'number'
         ? BigNumber.from(hex).toNumber()
-        : ethers.utils.toUtf8String(hex)
+        : ethersUtils.toUtf8String(hex)
   })

--- a/src/helpers/lib/methodRegistry.js
+++ b/src/helpers/lib/methodRegistry.js
@@ -1,5 +1,5 @@
 // From: https://github.com/danfinlay/eth-method-registry
-import { ethers } from 'ethers'
+import { Contract, providers as ethersProviders } from 'ethers'
 
 import { DEFAULT_ETH_NODE } from '../../defaults'
 
@@ -15,7 +15,7 @@ const REGISTRY_MAP = {
 export default class MethodRegistry {
   constructor (opts = {}) {
     this.provider =
-      opts.provider || new ethers.providers.WebSocketProvider(DEFAULT_ETH_NODE)
+      opts.provider || new ethersProviders.WebSocketProvider(DEFAULT_ETH_NODE)
     this.registryAddres = opts.registry || REGISTRY_MAP[opts.network]
   }
 
@@ -24,7 +24,7 @@ export default class MethodRegistry {
       throw new Error('No method registry found for the network.')
     }
 
-    this.registry = new ethers.Contract(
+    this.registry = new Contract(
       this.registryAddres,
       REGISTRY_LOOKUP_ABI,
       this.provider

--- a/src/helpers/tokenAmount.js
+++ b/src/helpers/tokenAmount.js
@@ -1,4 +1,4 @@
-import { ethers, BigNumber } from 'ethers'
+import { BigNumber, Contract, utils as ethersUtils } from 'ethers'
 
 import {
   ERC20_SYMBOL_BYTES32_ABI,
@@ -30,7 +30,7 @@ export default (provider) =>
         symbol = 'ETH'
       }
     } else {
-      let token = new ethers.Contract(
+      let token = new Contract(
         tokenAddress,
         ERC20_SYMBOL_DECIMALS_ABI,
         provider
@@ -42,13 +42,13 @@ export default (provider) =>
           symbol = (await token.symbol()) || ''
         } catch (err) {
           // Some tokens (e.g. DS-Token) use bytes32 for their symbol()
-          token = new ethers.Contract(
+          token = new Contract(
             tokenAddress,
             ERC20_SYMBOL_BYTES32_ABI,
             provider
           )
           symbol = (await token.symbol()) || ''
-          symbol = symbol && ethers.utils.toUtf8String(symbol)
+          symbol = symbol && ethersUtils.toUtf8String(symbol)
         }
       }
     }

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,5 @@
+import { knownFunctions } from './data'
+
 /**
  * @typedef {Object} Binding
  * @property {string} type The type of the binding (a valid Radspec type)
@@ -40,9 +42,10 @@ import { evaluateRaw } from './lib'
  * @param {?Object} options An options object
  * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
  * @param {?Object} options.userHelpers User defined helpers
+ * @param {?Object} options.userFunctions User defined function signatures
  * @return {Promise<string>} The result of the evaluation
  */
-function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
+function evaluate (source, call, { userHelpers = {}, userFunctions = {}, ...options } = {}) {
   // Create ethers interface object
   const ethersInterface = new ethers.utils.Interface(call.abi)
 
@@ -64,6 +67,8 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
 
   const availableHelpers = { ...defaultHelpers, ...userHelpers }
 
+  const availableFunctions = { ...knownFunctions, ...userFunctions }
+
   // Get additional options
   const { from, to, value, data } = call.transaction
 
@@ -71,6 +76,7 @@ function evaluate (source, call, { userHelpers = {}, ...options } = {}) {
   return evaluateRaw(source, parameters, {
     ...options,
     availableHelpers,
+    availableFunctions,
     from,
     to,
     value,

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ import { knownFunctions } from './data'
 /**
  * @module radspec
  */
-import { ethers } from 'ethers'
+import { utils as ethersUtils } from 'ethers'
 import { defaultHelpers } from './helpers'
 import { evaluateRaw } from './lib'
 
@@ -40,14 +40,14 @@ import { evaluateRaw } from './lib'
  * @param {string} call.transaction.to The destination address for this transaction
  * @param {string} call.transaction.data The transaction data
  * @param {?Object} options An options object
- * @param {?ethers.providers.Provider} options.provider EIP 1193 provider
+ * @param {?ethersProvider.Provider} options.provider EIP 1193 provider
  * @param {?Object} options.userHelpers User defined helpers
  * @param {?Object} options.userFunctions User defined function signatures
  * @return {Promise<string>} The result of the evaluation
  */
 function evaluate (source, call, { userHelpers = {}, userFunctions = {}, ...options } = {}) {
   // Create ethers interface object
-  const ethersInterface = new ethers.utils.Interface(call.abi)
+  const ethersInterface = new ethersUtils.Interface(call.abi)
 
   // Parse as an ethers TransactionDescription
   const { args, functionFragment } = ethersInterface.parseTransaction(

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -1,10 +1,10 @@
 import test from 'ava'
-import { BigNumber, ethers } from 'ethers'
+import { BigNumber, utils as ethersUtils } from 'ethers'
+import { knownFunctions } from '../../src/data'
 import { evaluateRaw } from '../../src/lib'
 import { defaultHelpers } from '../../src/helpers'
 import { tenPow } from '../../src/helpers/lib/formatBN'
 import { ETH } from '../../src/helpers/lib/token'
-import knownFunctions from '../../src/data/knownFunctions'
 
 const int = (value) => ({
   type: 'int256',
@@ -621,7 +621,7 @@ const cases = [
   [{
     source: 'Performs a call to `@radspec(contract, msg.data)`',
     bindings: { contract: address('0x960b236A07cf122663c4303350609A66A7B288C0') },
-    options: { data: ethers.utils.keccak256(ethers.utils.toUtf8Bytes(Object.keys(knownFunctions)[3])).slice(0, 10) }
+    options: { data: ethersUtils.keccak256(ethersUtils.toUtf8Bytes(Object.keys(knownFunctions)[3])).slice(0, 10) }
   }, `Performs a call to ${Object.values(knownFunctions)[3]}`],
 
   ...comparisonCases,
@@ -631,13 +631,14 @@ const cases = [
 
 cases.forEach(([input, expected], index) => {
   test(`${index} - ${input.source}`, async (t) => {
-    const { userHelpers } = input.options || {}
+    const { userHelpers, userFunctions } = input.options || {}
     const actual = await evaluateRaw(
       input.source,
       input.bindings,
       {
         ...input.options,
-        availableHelpers: { ...defaultHelpers, ...userHelpers }
+        availableHelpers: { ...defaultHelpers, ...userHelpers },
+        availableFunctions: { ...knownFunctions, ...userFunctions }
       }
     )
     t.is(

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -250,7 +250,7 @@ const dataDecodeCases = [
     source: 'Melonprotocol: `@radspec(addr, data)`',
     bindings: {
       addr: address(),
-      data: bytes('0x18e467f700000000000000000000000ec67005c4e498ec7f55e092bd1d35cbc47c918920000000000000000000000000000000000000000000000000000000000000001') // registerVersion(address,bytes32), on melonprotocol's knownFunctions
+      data: bytes('0x18e467f7000000000000000000000000ec67005c4e498ec7f55e092bd1d35cbc47c918920000000000000000000000000000000000000000000000000000000000000001') // registerVersion(address,bytes32), on melonprotocol's knownFunctions
     }
   }, 'Melonprotocol: Register new version 0xec67005c4E498Ec7f55E092bd1d35cbC47C91892'],
   [{
@@ -264,14 +264,14 @@ const dataDecodeCases = [
     source: 'Melonprotocol: `@radspec(addr, data)`',
     bindings: {
       addr: address(),
-      data: bytes('0xbda5310700000000000000000000000ec67005c4e498ec7f55e092bd1d35cbc47c91892') // setPriceSource(address), on melonprotocol's knownFunctions
+      data: bytes('0xbda53100700000000000000000000000ec67005c4e498ec7f55e092bd1d35cbc47c91892') // setPriceSource(address), on melonprotocol's knownFunctions
     }
   }, 'Melonprotocol: Set price source to 0xec67005c4E498Ec7f55E092bd1d35cbC47C91892'],
   [{
     source: 'Melonprotocol: `@radspec(addr, data)`',
     bindings: {
       addr: address(),
-      data: bytes('0x9e0a457000000000000000000000000ec67005c4e498ec7f55e092bd1d35cbc47c91892') // setMlnToken(address), on melonprotocol's knownFunctions
+      data: bytes('0x9e0a4570000000000000000000000000ec67005c4e498ec7f55e092bd1d35cbc47c91892') // setMlnToken(address), on melonprotocol's knownFunctions
     }
   }, 'Melonprotocol: Set Melon token to 0xec67005c4E498Ec7f55E092bd1d35cbC47C91892'],
   [{


### PR DESCRIPTION
This PR includes a new feature that allows consumers to define custom radspec descriptions for a list of known functions.

In the context of the Aragon Client, the consumer was not able to customize this list and that's why we have this data folder for each project: https://github.com/aragon/radspec/tree/master/src/data

With the help of Aragon Connect the above limitation is no longer relevant. Having a way to customize radspec descriptions is going to give much more flexibility to the Connect users.