### PR TITLE
Fix infinity loop issue

### DIFF
--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -514,20 +514,20 @@ export class Parser {
 
       this.matches('TICK')
 
-      let loopDetectorCursor = 0;
+      let loopDetectorCursor = 0
       let loopDetector = false
       while (!this.eof() && this.peek().type !== 'TICK') {
         node.body.push(this.walk(node.body))
-        loopDetectorCursor++;
+        loopDetectorCursor++
         if (loopDetectorCursor >= 10000) {
-          loopDetector = true;
-          break;        
+          loopDetector = true
+          break
         }
       }
 
       if (loopDetector) {
         while (!this.eof() && this.peek().type !== 'TICK') {
-          this.cursor++;
+          this.cursor++
         }
         this.report('Infinite loop detected')
       }

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -369,6 +369,13 @@ export class Parser {
       }
     }
 
+    if (this.matches('COLON')) {
+      return {
+        type: 'StringLiteral',
+        value: null
+      }
+    }
+
     this.report(`Unknown token "${this.consume().type}"`)
   }
 
@@ -507,8 +514,22 @@ export class Parser {
 
       this.matches('TICK')
 
+      let loopDetectorCursor = 0;
+      let loopDetector = false
       while (!this.eof() && this.peek().type !== 'TICK') {
         node.body.push(this.walk(node.body))
+        loopDetectorCursor++;
+        if (loopDetectorCursor >= 10000) {
+          loopDetector = true;
+          break;        
+        }
+      }
+
+      if (loopDetector) {
+        while (!this.eof() && this.peek().type !== 'TICK') {
+          this.cursor++;
+        }
+        this.report('Infinite loop detected')
       }
 
       if (this.eof()) {

--- a/test/examples/examples.js
+++ b/test/examples/examples.js
@@ -739,6 +739,14 @@ const cases = [
     source: "`a == 0x0 ? 'concat ' + a : 'else'`",
     bindings: { a: address('0x0000000000000000000000000000000000000001') }
   }, 'else'],
+  [{
+    source: "`a : 'concat ' + a : 'else'`",
+    bindings: { a: address('0x0000000000000000000000000000000000000001') }
+  }, '0x0000000000000000000000000000000000000001'],
+  [{
+    source: "`a == 0x0 : 'concat ' + a : 'else'`",
+    bindings: { a: address('0x0000000000000000000000000000000000000001') }
+  }, 'false  concat 0x0000000000000000000000000000000000000001  else'],
 
   // External calls
   [{


### PR DESCRIPTION
 Pay attention, the `@notice` parameter of the `assignVested` method in the TokenManager` contract breaks the `radspec` parser: there is a infinity loop. 
There are several options on how to fix this:
1. Correct the `notice` in the `TokenManager` contract;
2. Add simple protection from infinity loop;
3. Add a validation check for the AST tree.

Considering that the `radspec` and Token Manager contract has not been updated for a long time - there is a proposal to go on the first and second point.